### PR TITLE
Origin/form helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nb-configuration.xml
 /build/
 .idea/
 composer.lock
+*.swp

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "zendframework/zend-config": "^2.3",
+        "zendframework/zend-config": "^2.3 || ^3.0",
         "zendframework/zend-escaper": "^2.3",
         "zendframework/zend-form": "^2.3",
         "zendframework/zend-i18n": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "twitter/bootstrap": "Twitter bootstrap assets"
     },
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "zendframework/zend-config": "^2.3 || ^3.0",
         "zendframework/zend-escaper": "^2.3",
         "zendframework/zend-form": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
             "name": "Neilime",
             "homepage": "https://github.com/neilime",
             "role": "Developer"
+        },
+        {
+            "name": "Rolando Isidoro",
+            "homepage": "https://github.com/rolando-isidoro",
+            "role": "Developer"
         }
     ],
     "support": {

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,92 +1,102 @@
 <?php
 
-return array(
-    'twbshelper' => array(
-        'ignoredViewHelpers' => array(
-            'file',
-            'checkbox',
-            'radio',
-            'submit',
-            'multi_checkbox',
-            'static',
+return [
+    'twbshelper' => [
+        'ignoredViewHelpers' => [
             'button',
-            'reset'
-        ),
-        'type_map' => array(),
-        'class_map' => array(),
-    ),
-    'service_manager' => array(
-        'factories' => array(
+            'checkbox',
+            'file',
+            'multi_checkbox',
+            'radio',
+            'reset',
+            'submit',
+            'static',
+        ],
+        'type_map'  => [],
+        'class_map' => [],
+    ],
+
+    'service_manager' => [
+        'factories' => [
             'TwbsHelper\Options\ModuleOptions' => 'TwbsHelper\Options\Factory\ModuleOptionsFactory',
-        ),
-    ),
-    'view_helpers' => array(
-        'invokables' => array(
-            // View helpers
+        ],
+    ],
+
+    'view_helpers' => [
+        'invokables' => [
+            // Misc view helpers
             'abbreviation' => 'TwbsHelper\View\Helper\Abbreviation',
-            'alert' => 'TwbsHelper\View\Helper\Alert',
-            'badge' => 'TwbsHelper\View\Helper\Badge',
-            'blockquote' => 'TwbsHelper\View\Helper\Blockquote',
-            'figure' => 'TwbsHelper\View\Helper\Figure',
-            'htmlList' => 'TwbsHelper\View\Helper\HtmlList',
-            'table' => 'TwbsHelper\View\Helper\Table',
-            // Form helpers
-            'form' => 'TwbsHelper\Form\View\Helper\Form',
-            'formButton' => 'TwbsHelper\Form\View\Helper\FormButton',
-            'formSubmit' => 'TwbsHelper\Form\View\Helper\FormButton',
-            'formCheckbox' => 'TwbsHelper\Form\View\Helper\FormCheckbox',
-            'formCollection' => 'TwbsHelper\Form\View\Helper\FormCollection',
+            'alert'        => 'TwbsHelper\View\Helper\Alert',
+            'badge'        => 'TwbsHelper\View\Helper\Badge',
+            'blockquote'   => 'TwbsHelper\View\Helper\Blockquote',
+			'buttonGroup'  => 'TwbsHelper\View\Helper\ButtonGroup',
+            'figure'       => 'TwbsHelper\View\Helper\Figure',
+            'htmlList'     => 'TwbsHelper\View\Helper\HtmlList',
+            'table'        => 'TwbsHelper\View\Helper\Table',
+
+            // Form view helpers
+            'form'              => 'TwbsHelper\Form\View\Helper\Form',
+            'formButton'        => 'TwbsHelper\Form\View\Helper\FormButton',
+            'formSubmit'        => 'TwbsHelper\Form\View\Helper\FormButton',
+            'formCheckbox'      => 'TwbsHelper\Form\View\Helper\FormCheckbox',
+            'formCollection'    => 'TwbsHelper\Form\View\Helper\FormCollection',
             'formElementErrors' => 'TwbsHelper\Form\View\Helper\FormElementErrors',
             'formMultiCheckbox' => 'TwbsHelper\Form\View\Helper\FormMultiCheckbox',
-            'formRadio' => 'TwbsHelper\Form\View\Helper\FormRadio',
-            'formRow' => 'TwbsHelper\Form\View\Helper\FormRow',
-            'formStatic' => 'TwbsHelper\Form\View\Helper\FormStatic',
-            'formErrors' => 'TwbsHelper\Form\View\Helper\FormErrors',
+            'formRadio'         => 'TwbsHelper\Form\View\Helper\FormRadio',
+            'formRow'           => 'TwbsHelper\Form\View\Helper\FormRow',
+            'formStatic'        => 'TwbsHelper\Form\View\Helper\FormStatic',
+            'formErrors'        => 'TwbsHelper\Form\View\Helper\FormErrors',
+
             // Glyphicon
-            'glyphicon' => 'TwbsHelper\View\Helper\TwbsHelperGlyphicon',
+            'glyphicon' => 'TwbsHelper\View\Helper\Glyphicon',
+
             // FontAwesome
-            'fontAwesome' => 'TwbsHelper\View\Helper\TwbsHelperFontAwesome',
+            'fontAwesome' => 'TwbsHelper\View\Helper\FontAwesome',
+
             // ZF3
-            'form_button' => 'TwbsHelper\Form\View\Helper\FormButton',
-            'form_submit' => 'TwbsHelper\Form\View\Helper\FormButton',
-            'form_checkbox' => 'TwbsHelper\Form\View\Helper\FormCheckbox',
-            'form_collection' => 'TwbsHelper\Form\View\Helper\FormCollection',
+            'form_button'         => 'TwbsHelper\Form\View\Helper\FormButton',
+            'form_submit'         => 'TwbsHelper\Form\View\Helper\FormButton',
+            'form_checkbox'       => 'TwbsHelper\Form\View\Helper\FormCheckbox',
+            'form_collection'     => 'TwbsHelper\Form\View\Helper\FormCollection',
             'form_element_errors' => 'TwbsHelper\Form\View\Helper\FormElementErrors',
             'form_multi_checkbox' => 'TwbsHelper\Form\View\Helper\FormMultiCheckbox',
-            'form_radio' => 'TwbsHelper\Form\View\Helper\FormRadio',
-            'form_row' => 'TwbsHelper\Form\View\Helper\FormRow',
-            'form_static' => 'TwbsHelper\Form\View\Helper\FormStatic',
-            'form_errors' => 'TwbsHelper\Form\View\Helper\FormErrors',
-            'formbutton' => 'TwbsHelper\Form\View\Helper\FormButton',
-            'formsubmit' => 'TwbsHelper\Form\View\Helper\FormButton',
-            'formcheckbox' => 'TwbsHelper\Form\View\Helper\FormCheckbox',
-            'formcollection' => 'TwbsHelper\Form\View\Helper\FormCollection',
-            'formelement_errors' => 'TwbsHelper\Form\View\Helper\FormElementErrors',
-            'formmulticheckbox' => 'TwbsHelper\Form\View\Helper\FormMultiCheckbox',
-            'formradio' => 'TwbsHelper\Form\View\Helper\FormRadio',
-            'formrow' => 'TwbsHelper\Form\View\Helper\FormRow',
-            'formstatic' => 'TwbsHelper\Form\View\Helper\FormStatic',
-            'formerrors' => 'TwbsHelper\Form\View\Helper\FormErrors',
-            // zend
-            'form_label' => 'Zend\Form\View\Helper\FormLabel',
-            'formlabel' => 'Zend\Form\View\Helper\FormLabel',
-            'formemail' => 'Zend\Form\View\Helper\FormEmail',
+            'form_radio'          => 'TwbsHelper\Form\View\Helper\FormRadio',
+            'form_row'            => 'TwbsHelper\Form\View\Helper\FormRow',
+            'form_static'         => 'TwbsHelper\Form\View\Helper\FormStatic',
+            'form_errors'         => 'TwbsHelper\Form\View\Helper\FormErrors',
+            'formbutton'          => 'TwbsHelper\Form\View\Helper\FormButton',
+            'formsubmit'          => 'TwbsHelper\Form\View\Helper\FormButton',
+            'formcheckbox'        => 'TwbsHelper\Form\View\Helper\FormCheckbox',
+            'formcollection'      => 'TwbsHelper\Form\View\Helper\FormCollection',
+            'formelement_errors'  => 'TwbsHelper\Form\View\Helper\FormElementErrors',
+            'formfile'            => 'TwbsHelper\Form\View\Helper\FormFile',
+            'formmulticheckbox'   => 'TwbsHelper\Form\View\Helper\FormMultiCheckbox',
+            'formradio'           => 'TwbsHelper\Form\View\Helper\FormRadio',
+            'formrow'             => 'TwbsHelper\Form\View\Helper\FormRow',
+            'formstatic'          => 'TwbsHelper\Form\View\Helper\FormStatic',
+            'formerrors'          => 'TwbsHelper\Form\View\Helper\FormErrors',
+
+            // Zend
+            'form_label'   => 'Zend\Form\View\Helper\FormLabel',
+            'formlabel'    => 'Zend\Form\View\Helper\FormLabel',
+            'formemail'    => 'Zend\Form\View\Helper\FormEmail',
             'formpassword' => 'Zend\Form\View\Helper\FormPassword',
-            'formfile' => 'Zend\Form\View\Helper\FormFile',
-            'formtext' => 'Zend\Form\View\Helper\FormText',
+            'formtext'     => 'Zend\Form\View\Helper\FormText',
             'formtextarea' => 'Zend\Form\View\Helper\FormTextarea',
-            'formselect' => 'Zend\Form\View\Helper\FormSelect',
-            'forminput' => 'Zend\Form\View\Helper\FormInput',
-            'formhidden' => 'Zend\Form\View\Helper\FormHidden',
-        ),
-        'factories' => array(
-            'formElement' => 'TwbsHelper\Form\View\Helper\Factory\FormElementFactory',
-            'form_element' => 'TwbsHelper\Form\View\Helper\Factory\FormElementFactory',
-            'formelement' => 'TwbsHelper\Form\View\Helper\Factory\FormElementFactory',
+            'formselect'   => 'Zend\Form\View\Helper\FormSelect',
+            'forminput'    => 'Zend\Form\View\Helper\FormInput',
+            'formhidden'   => 'Zend\Form\View\Helper\FormHidden',
+        ],
+
+        'factories' => [
             'TwbsHelper\Form\View\Helper\FormElement' => 'TwbsHelper\Form\View\Helper\Factory\FormElementFactory',
-        ),
-        'aliases' => array(
+        ],
+
+        'aliases' => [
+            'formElement'  => 'TwbsHelper\Form\View\Helper\FormElement',
             'form_element' => 'TwbsHelper\Form\View\Helper\FormElement',
-        ),
-    ),
-);
+            'formelement'  => 'TwbsHelper\Form\View\Helper\FormElement',
+        ],
+    ],
+];
+

--- a/src/TwbsHelper/Form/Element/StaticElement.php
+++ b/src/TwbsHelper/Form/Element/StaticElement.php
@@ -1,0 +1,23 @@
+<?php
+namespace TwbsHelper\Form\Element;
+
+use Zend\Form\Element as ZendElement;
+
+/**
+ * StaticElement 
+ * 
+ * @uses ZendElement
+ */
+class StaticElement extends ZendElement
+{
+    /**
+     * Seed attributes
+     * 
+     * @var array
+     * @access protected
+     */
+    protected $attributes = [
+        'type' => 'static'
+    ];
+}
+

--- a/src/TwbsHelper/Form/View/Helper/Factory/FormElementFactory.php
+++ b/src/TwbsHelper/Form/View/Helper/Factory/FormElementFactory.php
@@ -1,0 +1,53 @@
+<?php
+namespace TwbsHelper\Form\View\Helper\Factory;
+
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
+
+use TwbsHelper\Form\View\Helper\FormElement;
+use TwbsHelper\Options\ModuleOptions;
+
+/**
+ * FormElementFactory 
+ * Factory to inject the ModuleOptions hard dependency
+ * 
+ * @uses FactoryInterface
+ */
+class FormElementFactory implements FactoryInterface
+{
+    /**
+     * createService 
+     * Compatibility with ZF2 (>= 2.2) -> proxy to __invoke
+     * 
+     * @param ServiceLocatorInterface $oServiceLocator 
+     * @param mixed $sCanonicalName 
+     * @param mixed $sRequestedName 
+     * @access public
+     * @return void
+     */
+    public function createService(ServiceLocatorInterface $oServiceLocator, $sCanonicalName = null, $sRequestedName = null)
+    {
+        return $this($oServiceLocator, $sRequestedName);
+    }
+
+
+    /**
+     * __invoke 
+     * Compatibility with ZF3
+     * 
+     * @param ContainerInterface $container 
+     * @param mixed $requestedName 
+     * @param array $options 
+     * @access public
+     * @return void
+     */
+    public function __invoke(ContainerInterface $oContainer, $sRequestedName, array $aOptions = null)
+    {
+        $oOptions = $oContainer->get(ModuleOptions::class);
+
+        return new FormElement($oOptions);
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/Form.php
+++ b/src/TwbsHelper/Form/View/Helper/Form.php
@@ -1,0 +1,216 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\View\Helper\Form as ZendFormViewHelper;
+use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
+
+
+/**
+ * Form 
+ * 
+ * @uses ZendFormViewHelper
+ */
+class Form extends ZendFormViewHelper
+{
+    const LAYOUT_HORIZONTAL = 'horizontal';
+    const LAYOUT_INLINE     = 'inline';
+
+    // @var string
+    protected static $sFormRowFormat = '<div class="row">%s</div>';
+
+    // Form layout (see LAYOUT_* consts)
+    // @var string
+    protected $sFormLayout = null;
+
+
+    /**
+     * __invoke 
+     * 
+     * @see    Form::__invoke()
+     * @param  FormInterface $oForm 
+     * @param  string $sFormLayout 
+     * @access public
+     * @return TwbsHelperForm|string
+     */
+    public function __invoke(FormInterface $oForm = null, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    {
+        $this->sFormLayout = $sFormLayout;
+
+        if ($oForm) {
+            return $this->render($oForm, $sFormLayout);
+        }
+
+        return $this;
+    }
+
+
+    /**
+     * render 
+     * Render a form from the provided $oForm,
+     * 
+     * @see    Form::render()
+     * @param  FormInterface $oForm 
+     * @param  string|null $sFormLayout 
+     * @access public
+     * @return string
+     */
+    public function render(FormInterface $oForm, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    {
+        // Prepare form if needed
+        if (method_exists($oForm, 'prepare')) {
+            $oForm->prepare();
+        }
+
+        $this->setFormClass($oForm, $sFormLayout);
+
+        // Set form role
+        if (!$oForm->getAttribute('role')) {
+            $oForm->setAttribute('role', 'form');
+        }
+
+        return $this->openTag($oForm) . "\n" . $this->renderElements($oForm, $sFormLayout) . $this->closeTag();
+    }
+
+
+    /**
+     * renderElements 
+     * 
+     * @param  FormInterface $oForm 
+     * @param  string|null $sFormLayout 
+     * @access protected
+     * @return string
+     */
+    protected function renderElements(FormInterface $oForm, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    {
+        // Store button groups
+        $aButtonGroups = [];
+
+        // Store button groups column-size from buttons
+        $aButtonGroupsColumnSize = [];
+
+        // Store elements rendering
+        $aElementsRendering = [];
+
+        // Retrieve view helper plugin manager
+        $oHelperPluginManager = $this->getView()->getHelperPluginManager();
+
+        // Retrieve form row helper
+        $oFormRowHelper = $oHelperPluginManager->get('formRow');
+
+        // Retrieve form collection helper
+        $oFormCollectionHelper = $oHelperPluginManager->get('formCollection');
+
+        // Retrieve button group helper
+        $oButtonGroupHelper = $oHelperPluginManager->get('buttonGroup');
+
+        // Store column size option
+        $bHasColumnSize = false;
+
+        // Prepare options
+        foreach ($oForm as $iKey => $oElement) {
+            $aOptions = $oElement->getOptions();
+
+            if (!$bHasColumnSize && !empty($aOptions['column-size'])) {
+                $bHasColumnSize = true;
+            }
+
+            // Define layout option to form elements if not already defined
+            if ($sFormLayout && empty($aOptions['twb-layout'])) {
+                $oElement->setOption('twb-layout', $sFormLayout);
+            }
+
+            // Manage button group option
+            if (isset($aOptions['button-group'])) {
+                $sButtonGroupKey = $aOptions['button-group'];
+
+                if (isset($aButtonGroups[$sButtonGroupKey])) {
+                    $aButtonGroups[$sButtonGroupKey][] = $oElement;
+
+                } else {
+                    $aButtonGroups[$sButtonGroupKey] = [$oElement];
+                    $aElementsRendering[$iKey]       = $sButtonGroupKey;
+                }
+
+                if (!empty($aOptions['column-size']) && !isset($aButtonGroupsColumnSize[$sButtonGroupKey])) {
+                    // Only the first occured column-size will be set, other are ignored.
+                    $aButtonGroupsColumnSize[$sButtonGroupKey] = $aOptions['column-size'];
+                }
+
+            } elseif ($oElement instanceof FieldsetInterface) {
+                $aElementsRendering[$iKey] = $oFormCollectionHelper->__invoke($oElement);
+
+            } else {
+                $aElementsRendering[$iKey] = $oFormRowHelper->__invoke($oElement);
+            }
+        }
+
+        // Assemble elements rendering
+        $sFormContent = '';
+
+        foreach ($aElementsRendering as $sElementRendering) {
+            // Check if element rendering is a button group key
+            if (isset($aButtonGroups[$sElementRendering])) {
+                $aButtons = $aButtonGroups[$sElementRendering];
+
+                // Render button group content
+                $options       = (isset($aButtonGroupsColumnSize[$sElementRendering])) ? ['attributes' => ['class' => 'col-' . $aButtonGroupsColumnSize[$sElementRendering]]] : null;
+                $sFormContent .= $oFormRowHelper->renderElementFormGroup($oButtonGroupHelper($aButtons, $options), $oFormRowHelper->getRowClassFromElement(current($aButtons)));
+
+            } else {
+                $sFormContent .= $sElementRendering;
+            }
+        }
+
+        if ($bHasColumnSize && self::LAYOUT_HORIZONTAL !== $sFormLayout) {
+            $sFormContent = sprintf(static::$sFormRowFormat, $sFormContent);
+        }
+
+        return $sFormContent;
+    }
+
+
+    /**
+     * setFormClass 
+     * Sets form layout class
+     * 
+     * @param  FormInterface $oForm 
+     * @param  string|null $sFormLayout 
+     * @access protected
+     * @return TwbsHelper\Form\View\Helper\TwbsHelperForm
+     */
+    protected function setFormClass(FormInterface $oForm, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    {
+        if (is_string($sFormLayout)) {
+            $sLayoutClass = 'form-' . $sFormLayout;
+
+            if ($sFormClass = $oForm->getAttribute('class')) {
+                if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sFormClass)) {
+                    $oForm->setAttribute('class', trim($sFormClass . ' ' . $sLayoutClass));
+                }
+
+            } else {
+                $oForm->setAttribute('class', $sLayoutClass);
+            }
+        }
+
+        return $this;
+    }
+
+
+    /**
+     * openTag 
+     * Generate an opening form tag
+     * 
+     * @param FormInterface|null $oForm 
+     * @access public
+     * @return string
+     */
+    public function openTag(FormInterface $oForm = null)
+    {
+        $this->setFormClass($oForm, $this->sFormLayout);
+
+        return parent::openTag($oForm);
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormButton.php
+++ b/src/TwbsHelper/Form/View/Helper/FormButton.php
@@ -1,0 +1,253 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use DomainException;
+use LogicException;
+use Exception;
+use Zend\Form\LabelAwareInterface;
+use Zend\Form\View\Helper\FormButton as ZendFormButtonViewHelper;
+use Zend\Form\ElementInterface;
+
+
+/**
+ * FormButton 
+ * 
+ * @uses ZendFormButtonViewHelper
+ */
+class FormButton extends ZendFormButtonViewHelper
+{
+    const ICON_PREPEND = 'prepend';
+    const ICON_APPEND  = 'append';
+
+    // @var string
+    protected static $sDropdownContainerFormat = '<div class="btn-group %s">%s</div>';
+
+    // @var string
+    protected static $sDropdownToggleFormat = '%s <b class="caret"></b>';
+
+    // @var string
+    protected static $sDropdownCaretFormat = '<button type="button" class="dropdown-toggle %s" data-toggle="dropdown"><span class="caret"></span></button>';
+
+    // Allowed button options
+    // @var array
+    protected static $aButtonOptions = [
+        'danger',
+        'dark', // Added in BS4
+        'info',
+        'light', // Added in BS4
+        'link',
+        'primary',
+        'secondary', // BS4 Renamed .btn-default to .btn-secondary
+        'success',
+        'warning',
+    ];
+
+
+    /**
+     * render 
+     * 
+     * @see    FormButton::render()
+     * @param  ElementInterface $oElement
+     * @param  string $sButtonContent
+     * @throws LogicException
+     * @throws Exception
+     * @return string
+     */
+    public function render(ElementInterface $oElement, $sButtonContent = null)
+    {
+        // Set classes assigned via attribute
+        if ($sClass = $oElement->getAttribute('class')) {
+            if (!preg_match('/(\s|^)btn(\s|$)/', $sClass)) {
+                $sClass .= ' btn';
+            }
+
+            if (!preg_match('/(\s|^)btn-.*(\s|$)/', $sClass)) {
+                $sClass .= ' btn-secondary';
+
+            } else {
+                $bHasOption = false;
+
+                foreach (static::$aButtonOptions as $sButtonOption) {
+                    if (preg_match('/(\s|^)btn-' . $sButtonOption . '.*(\s|$)/', $sClass)) {
+                        $bHasOption = true;
+                        break;
+                    }
+                }
+
+                if (!$bHasOption) {
+                    $sClass .= ' btn-secondary';
+                }
+            }
+            $oElement->setAttribute('class', trim($sClass));
+
+        // Set default classes since none were assigned
+        } else {
+            $oElement->setAttribute('class', 'btn btn-secondary');
+        }
+
+        // Retrieve icon options
+        if (null !== ($aIconOptions = $oElement->getOption('glyphicon'))) {
+            $sIconHelperMethod = 'glyphicon';
+
+        } elseif (null !== ($aIconOptions = $oElement->getOption('fontAwesome'))) {
+            $sIconHelperMethod = 'fontAwesome';
+        }
+
+        // Define button content
+        if (null === $sButtonContent) {
+            $sButtonContent = $oElement->getLabel();
+
+            if (!$sButtonContent) {
+                $sButtonContent = $oElement->getValue();
+            }
+
+            if (null === $sButtonContent && !$aIconOptions) {
+                throw new DomainException(sprintf(
+                    '%s expects either button content as the second argument, ' .
+                    'or that the element provided has a label value, a glyphicon option, or a fontAwesome option; none found',
+                    __METHOD__
+                ));
+            }
+
+            // Translate button content upon request
+            if (null !== ($oTranslator = $this->getTranslator())) {
+                $sButtonContent = $oTranslator->translate($sButtonContent, $this->getTranslatorTextDomain());
+            }
+        }
+
+        if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+            $oEscapeHtmlHelper = $this->getEscapeHtmlHelper();
+            $sButtonContent    = $oEscapeHtmlHelper($sButtonContent);
+        }
+
+        // Manage icon
+        if ($aIconOptions) {
+            // Set default icon options if scalar provided
+            if (is_scalar($aIconOptions)) {
+                $aIconOptions = [
+                    'icon'     => $aIconOptions,
+                    'position' => self::ICON_PREPEND
+                ];
+            }
+
+            // Validate icon options type
+            if (!is_array($aIconOptions)) {
+                throw new LogicException(sprintf(
+                    '"glyphicon" and "fontAwesome" button option expects a scalar value or an array, "%s" given',
+                    is_object($aIconOptions) ? get_class($aIconOptions) : gettype($aIconOptions)
+                ));
+            }
+
+            $position = 'prepend';
+
+            // Set icon position
+            if (!empty($aIconOptions['position'])) {
+                $position = $aIconOptions['position'];
+            }
+
+            // Set icon
+            if (!empty($aIconOptions['icon'])) {
+                $icon = $aIconOptions['icon'];
+            }
+
+            // Validate icon option type
+            if (!is_scalar($icon)) {
+                throw new LogicException(sprintf(
+                    'Glyphicon and fontAwesome "icon" option expects a scalar value, "%s" given',
+                    is_object($icon) ? get_class($icon) : gettype($icon)
+                ));
+
+            // Validate icon position option type
+            } elseif (!is_string($position)) {
+                throw new LogicException(sprintf(
+                    'Glyphicon and fontAwesome "position" option expects a string, "%s" given',
+                    is_object($position) ? get_class($position) : gettype($position)
+                ));
+
+            // Validate icon position option value
+            } elseif ($position !== self::ICON_PREPEND && $position !== self::ICON_APPEND) {
+                throw new LogicException(sprintf(
+                    'Glyphicon and fontAwesome "position" option allows "'.self::ICON_PREPEND.'" or "'.self::ICON_APPEND.'", "%s" given',
+                    is_object($position) ? get_class($position) : gettype($position)
+                ));
+            }
+
+            // Button content provided
+            if ($sButtonContent) {
+                // Prepend icon to button content
+                if ($position === self::ICON_PREPEND) {
+                    $sButtonContent = $this->getView()->{$sIconHelperMethod}(
+                        $icon,
+                        isset($aIconOptions['attributes']) ? $aIconOptions['attributes'] : null
+                    ) . " {$sButtonContent}";
+
+                // Append icon to button content
+                } else {
+                    $sButtonContent .= ' ' . $this->getView()->{$sIconHelperMethod}(
+                        $icon,
+                        isset($aIconOptions['attributes']) ? $aIconOptions['attributes'] : null
+                    );
+                }
+
+            // No button content provided, set icon as button content
+            } else {
+                $sButtonContent = $this->getView()->{$sIconHelperMethod}(
+                    $icon,
+                    isset($aIconOptions['attributes']) ? $aIconOptions['attributes'] : null
+                );
+            }
+        }
+
+
+        // Dropdown button
+        if ($aDropdownOptions = $oElement->getOption('dropdown')) {
+            // Validate dropdown option type
+            if (!is_array($aDropdownOptions)) {
+                throw new LogicException(sprintf(
+                    '"dropdown" option expects an array, "%s" given',
+                    is_object($aDropdownOptions) ? get_class($aDropdownOptions) : gettype($aDropdownOptions)
+                ));
+            }
+
+            // Split dropdown button
+            if (empty($aDropdownOptions['split'])) {
+                // Set class attribute
+                if (!preg_match('/(\s|^)dropdown-toggle(\s|$)/', $sClass = $oElement->getAttribute('class'))) {
+                    $oElement->setAttribute('class', trim($sClass . ' dropdown-toggle'));
+                }
+
+                // Set data-toggle attribute
+                $oElement->setAttribute('data-toggle', 'dropdown');
+
+                $sMarkup = $this->openTag($oElement) .
+                    sprintf(static::$sDropdownToggleFormat, $sButtonContent) .
+                    $this->closeTag();
+
+            // Regular dropdown button
+            } else {
+                // Add caret element
+                $sMarkup = $this->openTag($oElement) .
+                    $sButtonContent .
+                    $this->closeTag() .
+                    sprintf(static::$sDropdownCaretFormat, $oElement->getAttribute('class'));
+            }
+
+            // No container
+            if ($oElement->getOption('disable-twbs')) {
+                return $sMarkup . $this->getView()->dropdown()->renderListItems($aDropdownOptions);
+            }
+
+            // Render button + dropdown
+            return sprintf(
+                static::$sDropdownContainerFormat,
+                // Drop way
+                empty($aDropdownOptions['dropup']) ? '' : 'dropup',
+                $sMarkup .
+                $this->getView()->dropdown()->renderListItems($aDropdownOptions)
+            );
+        }
+
+        return $this->openTag($oElement) . $sButtonContent . $this->closeTag();
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
@@ -1,0 +1,165 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\View\Helper\FormRow;
+use Zend\Form\View\Helper\FormCheckbox as ZendFormCheckboxViewHelper;
+use Zend\Form\ElementInterface;
+use InvalidArgumentException;
+use LogicException;
+use Zend\Form\Element\Checkbox;
+use Zend\Form\View\Helper\FormLabel;
+
+
+/**
+ * FormCheckbox 
+ * 
+ * @uses ZendFormCheckboxViewHelper
+ */
+class FormCheckbox extends ZendFormCheckboxViewHelper
+{
+
+    // Form label helper instance
+    // @var FormLabel
+    protected $oLabelHelper;
+
+
+    /**
+     * render 
+     * 
+     * @see    ZendFormCheckboxViewHelper::render()
+     * @param  ElementInterface $oElement
+     * @throws LogicException
+     * @throws InvalidArgumentException
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        if ($oElement->getOption('disable-twbs')) {
+            return parent::render($oElement);
+        }
+
+        if (!$oElement instanceof Checkbox) {
+            throw new InvalidArgumentException(sprintf(
+                '%s requires that the element is of type Zend\Form\Element\Checkbox',
+                __METHOD__
+            ));
+        }
+        if (($sName = $oElement->getName()) !== 0 && empty($sName)) {
+            throw new LogicException(sprintf(
+                '%s requires that the element has an assigned name; none discovered',
+                __METHOD__
+            ));
+        }
+
+        $aAttributes          = $oElement->getAttributes();
+        $aAttributes['name']  = $sName;
+        $aAttributes['type']  = $this->getInputType();
+        $aAttributes['value'] = $oElement->getCheckedValue();
+        $aAttributes['class'] = $this->getClass();
+        $sClosingBracket      = $this->getInlineClosingBracket();
+
+        if ($oElement->isChecked()) {
+            $aAttributes['checked'] = 'checked';
+        }
+
+        // Render label
+        $sLabel         = '';
+        $sLabelContent  = $this->getLabelContent($oElement);
+
+        if ($sLabelContent) {
+            $oLabelHelper     = $this->getLabelHelper();
+            $aLabelAttributes = $oElement->getLabelAttributes();
+
+            // Set label "for" attribute with element "id" attribute when defined
+            if (empty($aLabelAttributes['for']) && !empty($aAttributes['id'])) {
+                $aLabelAttributes['for'] = $aAttributes['id'];
+            }
+
+            $sLabel = $oLabelHelper->openTag($aLabelAttributes) . $sLabelContent . $oLabelHelper->closeTag();
+        }
+
+        // Render checkbox
+        $sElementContent = sprintf('<input %s%s', $this->createAttributesString($aAttributes), $sClosingBracket);
+
+        // Attach label to input
+        $sElementContent .= $sLabel;
+
+        // Render hidden input
+        if ($oElement->useHiddenElement()) {
+            $sElementContent = sprintf(
+                '<input type="hidden" %s%s',
+                $this->createAttributesString([
+                    'name'  => $aAttributes['name'],
+                    'value' => $oElement->getUncheckedValue(),
+                ]),
+                $sClosingBracket
+            ) . $sElementContent;
+        }
+
+        return $sElementContent;
+    }
+
+    
+    /**
+     * getLabelContent 
+     * 
+     * @param ElementInterface $oElement 
+     * @access public
+     * @return string
+     */
+    public function getLabelContent(ElementInterface $oElement){
+        $sLabelContent = $oElement->getLabel();
+
+        if ($sLabelContent) {
+            if ($oTranslator = $this->getTranslator()) {
+                $sLabelContent = $oTranslator->translate($sLabelContent, $this->getTranslatorTextDomain());
+            }
+        }
+
+        return $sLabelContent;
+    }
+
+
+    /**
+     * getLabelHelper 
+     * Retrieve the FormLabel helper
+     * 
+     * @access protected
+     * @return FormLabel
+     */
+    protected function getLabelHelper()
+    {
+        if ($this->oLabelHelper) {
+            return $this->oLabelHelper;
+        }
+
+        if (method_exists($this->view, 'plugin')) {
+            $this->oLabelHelper = $this->view->plugin('form_label');
+        }
+
+        if (!($this->oLabelHelper instanceof FormLabel)) {
+            $this->oLabelHelper = new FormLabel();
+        }
+
+        if ($this->hasTranslator()) {
+            $this->oLabelHelper->setTranslator($this->getTranslator(), $this->getTranslatorTextDomain());
+        }
+
+        return $this->oLabelHelper;
+    }
+
+
+    /**
+     * getClass 
+     * Return class
+     * 
+     * @access protected
+     * @return void
+     */
+    protected function getClass()
+    {
+        return 'form-check-input';
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormCollection.php
+++ b/src/TwbsHelper/Form/View/Helper/FormCollection.php
@@ -1,0 +1,130 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\Element\Collection as CollectionElement;
+use Zend\Form\View\Helper\FormCollection as ZendFormCollectionViewHelper;
+use Zend\Form\ElementInterface;
+
+
+/**
+ * FormCollection 
+ * 
+ * @uses ZendFormCollectionViewHelper
+ */
+class FormCollection extends ZendFormCollectionViewHelper
+{
+    // @var string
+    protected static $legendFormat = '<legend%s>%s</legend>';
+
+    // @var string
+    protected static $fieldsetFormat = '<fieldset%s>%s</fieldset>';
+
+    // Attributes valid for the tag represented by this helper
+    // @var array
+    protected $validTagAttributes = [
+        'disabled' => true
+    ];
+
+
+    /**
+     * render 
+     * Render a collection by iterating through all fieldsets and elements
+     * 
+     * @param  \Zend\Form\ElementInterface $oElement
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        $oRenderer = $this->getView();
+
+        if (!method_exists($oRenderer, 'plugin')) {
+            return '';
+        }
+
+        $bShouldWrap    = $this->shouldWrap;
+        $sMarkup        = '';
+        $sElementLayout = $oElement->getOption('twbs-layout');
+
+        if ($oElement instanceof \IteratorAggregate) {
+            $oElementHelper  = $this->getElementHelper();
+            $oFieldsetHelper = $this->getFieldsetHelper();
+
+            foreach ($oElement->getIterator() as $oElementOrFieldset) {
+                $aOptions = $oElementOrFieldset->getOptions();
+
+                if ($sElementLayout && empty($aOptions['twbs-layout'])) {
+                    $aOptions['twbs-layout'] = $sElementLayout;
+                    $oElementOrFieldset->setOptions($aOptions);
+                }
+
+                if ($oElementOrFieldset instanceof \Zend\Form\FieldsetInterface) {
+                    $sMarkup .= $oFieldsetHelper($oElementOrFieldset);
+
+                } elseif ($oElementOrFieldset instanceof \Zend\Form\ElementInterface) {
+                	if ($oElementOrFieldset->getOption('twbs-row-open')) {
+						$sMarkup .= '<div class="row">' . "\n";
+					}
+
+					$sMarkup .= $oElementHelper($oElementOrFieldset);
+
+					if ($oElementOrFieldset->getOption('twbs-row-close')) {
+						$sMarkup .= '</div>' . "\n";
+					}
+                }
+            }
+            if ($oElement instanceof \Zend\Form\Element\Collection && $oElement->shouldCreateTemplate()) {
+                $sMarkup .= $this->renderTemplate($oElement);
+            }
+        }
+
+        if ($bShouldWrap) {
+            if (false != ($sLabel = $oElement->getLabel())) {
+                if (null !== ($oTranslator = $this->getTranslator())) {
+                    $sLabel = $oTranslator->translate($sLabel, $this->getTranslatorTextDomain());
+                }
+
+                $sMarkup = sprintf(
+                    static::$legendFormat, ($sAttributes = $this->createAttributesString($oElement->getLabelAttributes()? : [])) ? ' ' . $sAttributes : '', $this->getEscapeHtmlHelper()->__invoke($sLabel)
+                ) . $sMarkup;
+            }
+
+            // Set form layout class
+            if ($sElementLayout) {
+                $sLayoutClass = "form-{$sElementLayout}";
+
+                if (false != ($sElementClass = $oElement->getAttribute('class'))) {
+                    if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sElementClass)) {
+                        $oElement->setAttribute('class', trim("{$sElementClass} {$sLayoutClass}"));
+                    }
+                } else {
+                    $oElement->setAttribute('class', $sLayoutClass);
+                }
+            }
+
+            $sMarkup = sprintf(
+                    static::$fieldsetFormat, ($sAttributes = $this->createAttributesString($oElement->getAttributes())) ? " {$sAttributes}" : '', $sMarkup
+            );
+        }
+        return $sMarkup;
+    }
+
+    /**
+     * renderTemplate 
+     * Only render a template
+     * 
+     * @param CollectionElement $collection 
+     * @access public
+     * @return string
+     */
+    public function renderTemplate(CollectionElement $collection)
+    {
+        if (false != ($sElementLayout = $collection->getOption('twbs-layout'))) {
+            $elementOrFieldset = $collection->getTemplateElement();
+            $elementOrFieldset->setOption('twbs-layout', $sElementLayout);
+        }
+
+        return parent::renderTemplate($collection);
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -1,0 +1,341 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Traversable;
+use InvalidArgumentException;
+use LogicException;
+use Zend\Form\ElementInterface;
+use Zend\Form\View\Helper\FormElement as ZendFormElementViewHelper;
+use Zend\Form\Element\Collection;
+use Zend\Form\Factory;
+use Zend\I18n\Translator\TranslatorAwareInterface;
+use Zend\I18n\Translator\TranslatorInterface;
+use Zend\I18n\Translator\Translator;
+use Zend\Form\Element\Button;
+
+use TwbsHelper\Options\ModuleOptions;
+
+
+/**
+ * FormElement 
+ * 
+ * @uses ZendFormElementViewHelper
+ * @uses TranslatorAwareInterface
+ */
+class FormElement extends ZendFormElementViewHelper implements TranslatorAwareInterface
+{
+    // @var string
+    protected static $addonFormat = '<%s class="%s"><span class="input-group-text">%s</span></%s>';
+
+    // @var string
+    protected static $inputGroupFormat = '<div class="input-group %s">%s</div>';
+
+    // Translator (optional)
+    // @var Translator
+    protected $translator;
+
+    // Translator text domain (optional)
+    // @var string
+    protected $translatorTextDomain = 'default';
+
+    // Whether translator should be used
+    // @var boolean
+    protected $translatorEnabled = true;
+
+    // Hold configurable options
+    // @var ModuleOptions
+    protected $options;
+
+    // Instance map to view helper
+    // @var array
+    protected $classMap = [
+        'Zend\Form\Element\Button'              => 'formbutton',
+        'Zend\Form\Element\Captcha'             => 'formcaptcha',
+        'Zend\Form\Element\Csrf'                => 'formhidden',
+        'Zend\Form\Element\Collection'          => 'formcollection',
+        'Zend\Form\Element\DateTimeSelect'      => 'formdatetimeselect',
+        'Zend\Form\Element\DateSelect'          => 'formdateselect',
+        'Zend\Form\Element\MonthSelect'         => 'formmonthselect',
+        'TwbsHelper\Form\Element\StaticElement' => 'formStatic',
+    ];
+
+
+    /**
+     * __construct 
+     * 
+     * @param  ModuleOptions $options 
+     * @access public
+     * @return void
+     */
+    public function __construct(ModuleOptions $options)
+    {
+        if (is_array($options->getTypeMap())) {
+            $this->typeMap = array_merge($this->typeMap, $options->getTypeMap());
+        }
+
+        if (is_array($options->getClassMap())) {
+            $this->classMap = array_merge($this->classMap, $options->getClassMap());
+        }
+
+        $this->options = $options;
+    }
+
+
+    /**
+     * render 
+     * Render an element
+     * 
+     * @param  ElementInterface $oElement 
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        // Add form-control class
+        $sElementType = $oElement->getAttribute('type');
+
+        if (!in_array($sElementType, $this->options->getIgnoredViewHelpers()) &&
+            !($oElement instanceof Collection)
+        ) {
+            if ($sElementClass = $oElement->getAttribute('class')) {
+                if (!preg_match('/(\s|^)form-control(\s|$)/', $sElementClass)) {
+                    $oElement->setAttribute('class', trim($sElementClass . ' form-control'));
+                }
+            } else {
+                $oElement->setAttribute('class', 'form-control');
+            }
+        }
+
+        $sMarkup = parent::render($oElement);
+
+        // Addon prepend
+        if ($aAddOnPrepend = $oElement->getOption('add-on-prepend')) {
+            $sMarkup = $this->renderAddOn($aAddOnPrepend) . $sMarkup;
+        }
+
+        // Addon append
+        if ($aAddOnAppend = $oElement->getOption('add-on-append')) {
+            $sMarkup .= $this->renderAddOn($aAddOnAppend);
+        }
+
+        if ($aAddOnAppend || $aAddOnPrepend) {
+            $sSpecialClass = '';
+
+            // Input size
+            if ($sElementClass = $oElement->getAttribute('class')) {
+                if (preg_match('/(\s|^)input-lg(\s|$)/', $sElementClass)) {
+                    $sSpecialClass .= ' input-group-lg';
+                } elseif (preg_match('/(\s|^)input-sm(\s|$)/', $sElementClass)) {
+                    $sSpecialClass .= ' input-group-sm';
+                }
+            }
+
+            return sprintf(
+                static::$inputGroupFormat,
+                trim($sSpecialClass),
+                $sMarkup
+            );
+        }
+
+        return $sMarkup;
+    }
+
+
+    /**
+     * renderAddOn 
+     * Render addo-on markup
+     * 
+     * @param  ElementInterface|array|string $aAddOnOptions
+     * @param  string                        $sPosition 
+     * @throws InvalidArgumentException
+     * @throws LogicException
+     * @access protected
+     * @return string
+     */
+    protected function renderAddOn($aAddOnOptions, string $sPosition = 'prepend')
+    {
+        if (empty($aAddOnOptions)) {
+            throw new InvalidArgumentException('Addon options are empty');
+        }
+
+        if ($aAddOnOptions instanceof ElementInterface) {
+            $aAddOnOptions = ['element' => $aAddOnOptions];
+
+        } elseif (is_scalar($aAddOnOptions)) {
+            $aAddOnOptions = ['text' => $aAddOnOptions];
+
+        } elseif (!is_array($aAddOnOptions)) {
+            throw new InvalidArgumentException(sprintf(
+                'Addon options expects an array or a scalar value, "%s" given',
+                is_object($aAddOnOptions) ? get_class($aAddOnOptions) : gettype($aAddOnOptions)
+            ));
+        }
+
+        $sMarkup       = '';
+        $sAddonTagName = 'div';
+        $sAddonClass   = '';
+
+        if (!empty($aAddOnOptions['text'])) {
+            if (!is_scalar($aAddOnOptions['text'])) {
+                throw new InvalidArgumentException(sprintf(
+                    '"text" option expects a scalar value, "%s" given',
+                    is_object($aAddOnOptions['text']) ? get_class($aAddOnOptions['text']) : gettype($aAddOnOptions['text'])
+                ));
+
+            } elseif (($oTranslator = $this->getTranslator())) {
+                $sMarkup .= $oTranslator->translate($aAddOnOptions['text'], $this->getTranslatorTextDomain());
+
+            } else {
+                $sMarkup .= $aAddOnOptions['text'];
+            }
+
+            $sAddonClass .= ('prepend' == $sPosition) ? ' input-group-prepend' : 'input-group-append';
+
+        } elseif (!empty($aAddOnOptions['element'])) {
+            if (is_array($aAddOnOptions['element']) ||
+                ($aAddOnOptions['element'] instanceof Traversable &&
+                !($aAddOnOptions['element'] instanceof ElementInterface))
+            ) {
+                $oFactory = new Factory();
+                $aAddOnOptions['element'] = $oFactory->create($aAddOnOptions['element']);
+
+            } elseif (!($aAddOnOptions['element'] instanceof ElementInterface)) {
+                throw new LogicException(sprintf(
+                    '"element" option expects an instanceof Zend\Form\ElementInterface, "%s" given',
+                    is_object($aAddOnOptions['element']) ? get_class($aAddOnOptions['element']) : gettype($aAddOnOptions['element'])
+                ));
+            }
+
+            $aAddOnOptions['element']->setOptions(array_merge(
+                $aAddOnOptions['element']->getOptions(),
+                ['disable-twbs' => true]
+            ));
+
+            $sMarkup .= $this->render($aAddOnOptions['element']);
+
+            //Element is a button, so add-on container must be a "div"
+            if ($aAddOnOptions['element'] instanceof Button) {
+                $sAddonClass .= ' input-group-btn';
+                $sAddonTagName = 'div';
+
+            } else {
+                $sAddonClass .= ' input-group-addon';
+            }
+        }
+
+        return sprintf(static::$addonFormat, $sAddonTagName, trim($sAddonClass), $sMarkup, $sAddonTagName);
+    }
+
+
+    /**
+     * setTranslator 
+     * Sets translator to use in helper
+     * 
+     * @see    TranslatorAwareInterface::setTranslator()
+     * @param  TranslatorInterface $oTranslator : [optional] translator. Default is null, which sets no translator.
+     * @param  string $sTextDomain : [optional] text domain Default is null, which skips setTranslatorTextDomain
+     * @access public
+     * @return TwbsHelperFormElement
+     */
+    public function setTranslator(TranslatorInterface $oTranslator = null, $sTextDomain = null)
+    {
+        $this->translator = $oTranslator;
+
+        if (null !== $sTextDomain) {
+            $this->setTranslatorTextDomain($sTextDomain);
+        }
+
+        return $this;
+    }
+
+
+    /**
+     * getTranslator 
+     * Returns translator used in helper
+     *
+     * @see    TranslatorAwareInterface::getTranslator()
+     * @access public
+     * @return null|TranslatorInterface
+     */
+    public function getTranslator()
+    {
+        return $this->isTranslatorEnabled() ? $this->translator : null;
+    }
+
+
+    /**
+     * hasTranslator 
+     * Checks if the helper has a translator
+     * 
+     * @see    TranslatorAwareInterface::hasTranslator()
+     * @access public
+     * @return boolean
+     */
+    public function hasTranslator()
+    {
+        return !!$this->getTranslator();
+    }
+
+
+    /**
+     * setTranslatorEnabled 
+     * Sets whether translator is enabled and should be used
+     * 
+     * @see    TranslatorAwareInterface::setTranslatorEnabled()
+     * @param  boolean $bEnabled
+     * @access public
+     * @return TwbsHelperFormElement
+     */
+    public function setTranslatorEnabled($bEnabled = true)
+    {
+        $this->translatorEnabled = !!$bEnabled;
+
+        return $this;
+    }
+
+
+    /**
+     * isTranslatorEnabled 
+     * Returns whether translator is enabled and should be used
+     * 
+     * @see    TranslatorAwareInterface::isTranslatorEnabled()
+     * @access public
+     * @return boolean
+     */
+    public function isTranslatorEnabled()
+    {
+        return $this->translatorEnabled;
+    }
+
+
+    /**
+     * setTranslatorTextDomain 
+     * Set translation text domain
+     * 
+     * @see    TranslatorAwareInterface::setTranslatorTextDomain()
+     * @param  string $sTextDomain
+     * @access public
+     * @return TwbsHelperFormElement
+     */
+    public function setTranslatorTextDomain($sTextDomain = 'default')
+    {
+        $this->translatorTextDomain = $sTextDomain;
+
+        return $this;
+    }
+
+
+    /**
+     * getTranslatorTextDomain 
+     * Return the translation text domain
+     * 
+     * @see    TranslatorAwareInterface::getTranslatorTextDomain()
+     * @access public
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->translatorTextDomain;
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormElementErrors.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElementErrors.php
@@ -1,0 +1,18 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\View\Helper\FormElementErrors as ZendFormElementErrorsViewHelper;
+
+
+/**
+ * FormElementErrors 
+ * 
+ * @uses ZendFormElementErrorsViewHelper
+ */
+class FormElementErrors extends ZendFormElementErrorsViewHelper
+{
+    protected $attributes = [
+        'class' => 'form-text'
+    ];
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormErrors.php
+++ b/src/TwbsHelper/Form/View/Helper/FormErrors.php
@@ -1,0 +1,99 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\View\Helper\AbstractHelper;
+use Zend\Form\FormInterface;
+
+
+/**
+ * FormErrors 
+ * 
+ * @uses AbstractHelper
+ */
+class FormErrors extends AbstractHelper
+{
+    protected $sDefaultErrorText       = 'There were errors in the form submission';
+    protected $sMessageOpenFormat      = '<h4>%s</h4><ul><li>';
+    protected $sMessageCloseString     = '</li></ul>';
+    protected $sMessageSeparatorString = '</li><li>';
+
+
+    /**
+     * __invoke 
+     * Invoke as function
+     * 
+     * @param  \Zend\Form\FormInterface $oForm
+     * @param  string $sMessage
+     * @param  string $bDismissable
+     * @access public
+     * @return string|null
+     */
+    public function __invoke(FormInterface $oForm = null, $sMessage = null, $bDismissable = false)
+    {
+        if (!$oForm) {
+            return $this;
+        }
+
+        if (!$sMessage) {
+            $sMessage = $this->sDefaultErrorText;
+        }
+
+        if ($oForm->hasValidated() && !$oForm->isValid()) {
+            return $this->render($oForm, $sMessage, $bDismissable);
+        }
+
+        return null;
+    }
+
+
+    /**
+     * render 
+     * Renders the error messages.
+     * 
+     * @param \Zend\Form\FormInterface $oForm
+     * @access public
+     * @return string
+     */
+    public function render(FormInterface $oForm, $sMessage, $bDismissable = false)
+    {
+        $errorHtml = sprintf($this->sMessageOpenFormat, $sMessage);
+        $aMessages = [];
+
+        foreach ($oForm->getMessages() as $fieldName => $aFormMessages) {
+            foreach ($aFormMessages as $sFormMessage) {
+                if ($oForm->get($fieldName)->getAttribute('id')) {
+                    $aMessages[] = sprintf(
+                        '<a href="#%s">%s</a>',
+                        $oForm->get($fieldName)->getAttribute('id'),
+                        $oForm->get($fieldName)->getLabel() . ': ' . $sFormMessage
+                    );
+
+                } else {
+                    $aMessages[] = $oForm->get($fieldName)->getLabel() . ': ' . $sFormMessage;
+                }
+            }
+        }
+
+        return $this->dangerAlert(
+            $errorHtml .
+            implode($this->sMessageSeparatorString, $aMessages) .
+            $this->sMessageCloseString,
+            $bDismissable
+        );
+    }
+
+
+    /**
+     * dangerAlert 
+     * Creates and returns a "danger" alert.
+     * 
+     * @param string  $content
+     * @param boolean $bDismissable
+     * @return string
+     */
+    public function dangerAlert($content, $bDismissable = false)
+    {
+        return $this->getView()->alert($content, array('class' => 'alert-danger'), $bDismissable);
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormFile.php
+++ b/src/TwbsHelper/Form/View/Helper/FormFile.php
@@ -1,0 +1,91 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+use Zend\Form\Exception;
+use Zend\Form\View\Helper\FormInput;
+
+
+/**
+ * FormFile 
+ * 
+ * @uses FormInput
+ */
+class FormFile extends FormInput
+{
+    /**
+     * Attributes valid for the input tag type="file"
+     *
+     * @var array
+     */
+    protected $validTagAttributes = [
+        'name'      => true,
+        'accept'    => true,
+        'autofocus' => true,
+        'disabled'  => true,
+        'form'      => true,
+        'multiple'  => true,
+        'required'  => true,
+        'type'      => true,
+    ];
+
+    /**
+     * render 
+     * Render a form <input> element from the provided $oElement
+     *
+     * @param  ElementInterface $oElement
+     * @throws Exception\DomainException
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        $sName = $oElement->getName();
+
+        if (null === $sName || '' === $sName) {
+            throw new Exception\DomainException(sprintf(
+                '%s requires that the element has an assigned name; none discovered',
+                __METHOD__
+            ));
+        }
+
+        $aAttributes          = $oElement->getAttributes();
+        $aAttributes['type']  = $this->getType($oElement);
+        $aAttributes['name']  = $sName;
+
+        if (array_key_exists('multiple', $aAttributes) && $aAttributes['multiple']) {
+            $aAttributes['name'] .= '[]';
+        }
+
+        $sValue = $oElement->getValue();
+
+        if (is_array($sValue) && isset($sValue['name']) && ! is_array($sValue['name'])) {
+            $aAttributes['value'] = $sValue['name'];
+
+        } elseif (is_string($sValue)) {
+            $aAttributes['value'] = $sValue;
+        }
+
+		// Add BS4 form-control-file class if not set
+		$aAttributes['class']  = !empty($aAttributes['class']) ? $aAttributes['class'] : '';
+		$aAttributes['class'] .= (false === strpos($aAttributes['class'], 'form-control-file')) ? ' form-control-file' : '';
+
+        return sprintf(
+            '<input %s%s',
+            $this->createAttributesString($aAttributes),
+            $this->getInlineClosingBracket()
+        );
+    }
+
+    /**
+     * Determine input type to use
+     *
+     * @param  ElementInterface $oElement
+     * @return string
+     */
+    protected function getType(ElementInterface $oElement)
+    {
+        return 'file';
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormMultiCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormMultiCheckbox.php
@@ -1,0 +1,170 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\Element\MultiCheckbox;
+use Zend\Form\View\Helper\FormMultiCheckbox as ZendFormMultiCheckboxViewHelper;
+use Zend\Form\ElementInterface;
+
+
+/**
+ * FormMultiCheckbox 
+ * 
+ * @uses ZendFormMultiCheckboxViewHelper
+ */
+class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
+{
+    /**
+     * render 
+     * 
+     * @see    FormMultiCheckbox::render()
+     * @param  ElementInterface $oElement
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        $aElementOptions  = $oElement->getOptions();
+        $sClass           = 'form-check';
+        $sClass          .= isset($aElementOptions['inline']) && $aElementOptions['inline'] ? ' form-check-inline' : '';
+
+        $this->setSeparator("</div><div class='{$sClass}'>");
+        $oElement->setAttribute('class', 'form-check-input');
+        $oElement->setLabelAttributes(['class' => 'form-check-label']);
+
+        return sprintf("<div class='{$sClass}'>%s</div>", parent::render($oElement));
+    }
+
+
+    /**
+     * renderOptions 
+     * Render options
+     *
+     * @param  MultiCheckbox $oElement
+     * @param  array         $aOptions
+     * @param  array         $selectedOptions
+     * @param  array         $aAttributes
+     * @return string
+     */
+    protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $selectedOptions, array $aAttributes) {
+        $oEscapeHtmlHelper      = $this->getEscapeHtmlHelper();
+        $oLabelHelper           = $this->getLabelHelper();
+        $sLabelClose            = $oLabelHelper->closeTag();
+        $sLabelPosition         = $this->getLabelPosition();
+        $aGlobalLabelAttributes = $oElement->getLabelAttributes();
+        $sClosingBracket        = $this->getInlineClosingBracket();
+
+        if ($oElement instanceof LabelAwareInterface) {
+            $aGlobalLabelAttributes = $oElement->getLabelAttributes();
+        }
+
+        if (empty($aGlobalLabelAttributes)) {
+            $aGlobalLabelAttributes = $this->labelAttributes;
+        }
+
+        $aCombinedMarkup = [];
+        $iCount          = 0;
+
+        foreach ($aOptions as $sKey => $aOptionSpec) {
+            $iCount++;
+
+            if ($iCount > 1 && array_key_exists('id', $aAttributes)) {
+                unset($aAttributes['id']);
+            }
+
+            $sValue           = '';
+            $sLabel           = '';
+            $aInputAttributes = $aAttributes;
+            $aLabelAttributes = $aGlobalLabelAttributes;
+            $bSelected        = (isset($aInputAttributes['selected'])
+                && $aInputAttributes['type'] != 'radio'
+                && $aInputAttributes['selected']);
+            $bDisabled        = (isset($aInputAttributes['disabled']) && $aInputAttributes['disabled']);
+
+            if (is_scalar($aOptionSpec)) {
+                $aOptionSpec = [
+                    'label' => $aOptionSpec,
+                    'value' => $sKey
+                ];
+            }
+
+            if (isset($aOptionSpec['value'])) {
+                $sValue = $aOptionSpec['value'];
+            }
+
+            if (isset($aOptionSpec['label'])) {
+                $sLabel = $aOptionSpec['label'];
+            }
+
+            if (isset($aOptionSpec['selected'])) {
+                $bSelected = $aOptionSpec['selected'];
+            }
+
+            if (isset($aOptionSpec['disabled'])) {
+                $bDisabled = $aOptionSpec['disabled'];
+            }
+
+            if (isset($aOptionSpec['attributes'])) {
+                $aInputAttributes = array_merge($aInputAttributes, $aOptionSpec['attributes']);
+            }
+
+            if (in_array($sValue, $selectedOptions)) {
+                $bSelected = true;
+            }
+
+            $aInputAttributes['value']    = $sValue;
+            $aInputAttributes['checked']  = $bSelected;
+            $aInputAttributes['disabled'] = $bDisabled;
+
+            $input = sprintf(
+                '<input %s%s',
+                $this->createAttributesString($aInputAttributes),
+                $sClosingBracket
+            );
+
+            if (null !== ($translator = $this->getTranslator())) {
+                $sLabel = $translator->translate(
+                    $sLabel,
+                    $this->getTranslatorTextDomain()
+                );
+            }
+
+            if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+                $sLabel = $oEscapeHtmlHelper($sLabel);
+            }
+
+            // Label
+            // Set label attributes
+            if (isset($aOptionSpec['label_attributes'])) {
+                $aLabelAttributes = (isset($aLabelAttributes))
+                    ? array_merge($aLabelAttributes, $aOptionSpec['label_attributes'])
+                    : $aOptionSpec['label_attributes'];
+            }
+
+            // Assign label for attribute with element id attribute when defined
+            if (empty($aLabelAttributes['for']) && !empty($aInputAttributes['id'])) {
+                $aLabelAttributes['for'] = $aInputAttributes['id'];
+            }
+
+            // Create label markup
+            $sLabelOpen = $oLabelHelper->openTag($aLabelAttributes);
+            $sLabel     = $sLabelOpen . $sLabel . $sLabelClose;
+
+            // Attach label to input
+            switch ($sLabelPosition) {
+                case self::LABEL_PREPEND:
+                    $markup = $sLabel . $input;
+                    break;
+
+                case self::LABEL_APPEND:
+                default:
+                    $markup = $input . $sLabel;
+                    break;
+            }
+
+            $aCombinedMarkup[] = $markup;
+        }
+
+        return implode($this->getSeparator(), $aCombinedMarkup);
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormRadio.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRadio.php
@@ -1,0 +1,183 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\View\Helper\FormRadio as ZendFormRadioViewHelper;
+use Zend\Form\ElementInterface;
+use Zend\Form\Element\MultiCheckbox;
+
+
+/**
+ * FormRadio 
+ * 
+ * @uses ZendFormRadioViewHelper
+ */
+class FormRadio extends ZendFormRadioViewHelper
+{
+    // Separator for checkbox elements
+    // @var string
+    protected $separator = '</div><div class="form-check">';
+
+    // @var string
+    protected static $checkboxFormat = '<div class="form-check">%s</div>';
+
+
+    /**
+     * render 
+     * 
+     * @see    \Zend\Form\View\Helper\FormRadio::render()
+     * @param  \Zend\Form\ElementInterface $oElement
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        $aElementOptions = $oElement->getOptions();
+
+        // Render using default Zend\Form\View\Helper\FormRadio
+        if (isset($aElementOptions['disable-twbs']) && $aElementOptions['disable-twbs']) {
+            $sSeparator = $this->getSeparator();
+            $this->setSeparator('');
+            $sReturn = parent::render($oElement);
+            $this->setSeparator($sSeparator);
+
+            return $sReturn;
+        }
+
+        if (isset($aElementOptions['inline']) && $aElementOptions['inline'] == true) {
+            $sSeparator = $this->getSeparator();
+            $this->setSeparator('');
+            $oElement->setLabelAttributes(['class' => 'form-check-inline']);
+            $sReturn = sprintf('%s', parent::render($oElement));
+            $this->setSeparator($sSeparator);
+
+            return $sReturn;
+        }
+
+        if (isset($aElementOptions['btn-group']) && $aElementOptions['btn-group'] != false) {
+            $buttonClass = 'btn btn-primary';
+
+            if (is_array($aElementOptions['btn-group']) && isset($aElementOptions['btn-group']['btn-class'])) {
+                $buttonClass = $aElementOptions['btn-group']['btn-class'];
+            }
+
+        	$this->setSeparator('');
+        	$oElement->setLabelAttributes(['class' => $buttonClass]);
+
+        	return sprintf('<div class="btn-group" data-toggle="buttons">%s</div>', parent::render($oElement));
+        }
+
+        return sprintf(static::$checkboxFormat, parent::render($oElement));
+    }
+
+
+    /**
+     * renderOptions 
+     * 
+     * @see    \Zend\Form\View\Helper\FormMultiCheckbox::renderOptions()
+     * @param  \Zend\Form\Element\MultiCheckbox $oElement
+     * @param  array $aOptions
+     * @param  array $aSelectedOptions
+     * @param  array $aAttributes
+     * @access protected
+     * @return string
+     */
+    protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $aSelectedOptions, array $aAttributes) {
+        $iIterator              = 0;
+        $aGlobalLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
+        $sMarkup                = '';
+        $oLabelHelper           = $this->getLabelHelper();
+        $aElementOptions        = $oElement->getOptions();
+
+        foreach ($aOptions as $key => $aOptionspec) {
+            if (is_scalar($aOptionspec)) {
+                $aOptionspec = ['label' => $aOptionspec, 'value' => $key];
+            }
+
+            $iIterator++;
+            if ($iIterator > 1 && array_key_exists('id', $aAttributes)) {
+                unset($aAttributes['id']);
+            }
+
+            // Option attributes
+            $aInputAttributes = $aAttributes;
+            if (isset($aOptionspec['attributes'])) {
+                $aInputAttributes = \Zend\Stdlib\ArrayUtils::merge($aInputAttributes, $aOptionspec['attributes']);
+            }
+
+			// Add BS4 form-check-input class if not set
+			$aInputAttributes['class']  = !empty($aInputAttributes['class']) ? $aInputAttributes['class'] : '';
+			$aInputAttributes['class'] .= (false === strpos($aInputAttributes['class'], 'form-check-label')) ? ' form-check-input' : '';
+
+
+            // Option value
+            $aInputAttributes['value'] = isset($aOptionspec['value']) ? $aOptionspec['value'] : '';
+
+            // Selected option
+            if (in_array($aInputAttributes['value'], $aSelectedOptions)) {
+                $aInputAttributes['checked'] = true;
+
+            } elseif (isset($aOptionspec['selected'])) {
+                $aInputAttributes['checked'] = !!$aOptionspec['selected'];
+
+            } else {
+                $aInputAttributes['checked'] = isset($aInputAttributes['selected']) && $aInputAttributes['type'] !== 'radio' && $aInputAttributes['selected'] != false;
+            }
+
+            // Disabled option
+            if (isset($aOptionspec['disabled'])) {
+                $aInputAttributes['disabled'] = !!$aOptionspec['disabled'];
+
+            } else {
+                $aInputAttributes['disabled'] = isset($aInputAttributes['disabled']) && $aInputAttributes['disabled'] != false;
+            }
+
+            // Render option
+            $sOptionMarkup = sprintf('<input %s%s', $this->createAttributesString($aInputAttributes), $this->getInlineClosingBracket());
+
+            //Option label
+            $sLabel = isset($aOptionspec['label']) ? $aOptionspec['label'] : '';
+
+            if ($sLabel) {
+                $aLabelAttributes = $aGlobalLabelAttributes;
+
+				// Add BS4 form-check-label class if not set
+				$aLabelAttributes['class']  = !empty($aLabelAttributes['class']) ? $aLabelAttributes['class'] : '';
+				$aLabelAttributes['class'] .= (false === strpos($aLabelAttributes['class'], 'form-check-label')) ? ' form-check-label' : '';
+
+                if (isset($aElementOptions['btn-group']) && $aElementOptions['btn-group'] == true) {
+                	if ($aInputAttributes['checked']) {
+                		$aLabelAttributes['class'] = ((isset($aLabelAttributes['class'])) ? $aLabelAttributes['class'] : '') . ' active';
+                	}
+                }
+
+                if (isset($aOptionspec['label_attributes'])) {
+                    $aLabelAttributes = isset($aLabelAttributes) ? array_merge($aLabelAttributes, $aOptionspec['label_attributes']) : $aOptionspec['label_attributes'];
+                }
+
+                if (null !== ($oTranslator = $this->getTranslator())) {
+                    $sLabel = $oTranslator->translate($sLabel, $this->getTranslatorTextDomain());
+                }
+
+                if (!($oElement instanceof \Zend\Form\LabelAwareInterface) || !$oElement->getLabelOption('disable_html_escape')) {
+                    $sLabel = $this->getEscapeHtmlHelper()->__invoke($sLabel);
+                }
+
+                switch ($this->getLabelPosition()) {
+                    case self::LABEL_PREPEND:
+                        $sOptionMarkup = sprintf($oLabelHelper->openTag($aLabelAttributes) . '%s' . $oLabelHelper->closeTag() . '%s', $sLabel, $sOptionMarkup);
+                        break;
+
+                    case self::LABEL_APPEND:
+                    default:
+                        $sOptionMarkup = sprintf('%s' . $oLabelHelper->openTag($aLabelAttributes) . '%s' . $oLabelHelper->closeTag(), $sOptionMarkup, $sLabel);
+                        break;
+                }
+            }
+
+            $sMarkup .= ($sMarkup ? $this->getSeparator() : '') . $sOptionMarkup;
+        }
+
+        return $sMarkup;
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -1,0 +1,408 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use DomainException;
+use Zend\Form\View\Helper\FormRow as ZendFormRowViewHelper;
+use Zend\Form\ElementInterface;
+use Zend\Form\LabelAwareInterface;
+use Zend\Form\Element\Button;
+use Zend\Form\Element\Submit;
+
+
+/**
+ * FormRow 
+ * 
+ * @uses ZendFormRowViewHelper
+ */
+class FormRow extends ZendFormRowViewHelper
+{
+    /**
+     * @var string
+     */
+    protected static $formGroupFormat = '<div class="form-group %s">%s</div>';
+
+    /**
+     * @var string
+     */
+    protected static $horizontalLayoutFormat = '<div class="%s">%s</div>';
+
+    /**
+     * @var string
+     */
+    protected static $checkboxFormat = '<div class="form-check">%s</div>';
+
+    /**
+     * @var string
+     */
+    protected static $helpBlockFormat = '<p class="help-block">%s</p>';
+
+    /**
+     * The class that is added to element that have errors
+     * @var string
+     */
+    protected $inputErrorClass = '';
+
+    /**
+     * @var string
+     */
+    protected $requiredFormat = null;
+
+
+    /**
+     * render 
+     * 
+     * @see    FormRow::render()
+     * @param  ElementInterface $oElement 
+     * @param  mixed $sLabelPosition 
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement, $sLabelPosition = null)
+    {
+        // Retrieve element type
+        $sElementType = $oElement->getAttribute('type');
+
+        // Nothing to do for hidden elements which have no messages
+        if ('hidden' === $sElementType && !$oElement->getMessages()) {
+            return parent::render($oElement, $sLabelPosition);
+        }
+
+        // Retrieve expected layout
+        $sLayout = $oElement->getOption('twbs-layout');
+
+        // Define label position
+        if ($sLabelPosition === null) {
+            $sLabelPosition = $this->getLabelPosition();
+        }
+
+        // Partial rendering
+        if ($this->partial) {
+            return $this->view->render(
+                $this->partial,
+                [
+                    'element'         => $oElement,
+                    'label'           => $this->renderLabel($oElement),
+                    'labelAttributes' => $this->labelAttributes,
+                    'labelPosition'   => $sLabelPosition,
+                    'renderErrors'    => $this->renderErrors,
+                ]
+            );
+        }
+
+        // "has-error" validation state case
+        if ($oElement->getMessages()) {
+            //Element have errors
+            if ($sInputErrorClass = $this->getInputErrorClass()) {
+                if ($sElementClass = $oElement->getAttribute('class')) {
+                    if (!preg_match('/(\s|^)' . preg_quote($sInputErrorClass, '/') . '(\s|$)/', $sElementClass)) {
+                        $oElement->setAttribute('class', trim($sElementClass . ' ' . $sInputErrorClass));
+                    }
+
+                } else {
+                    $oElement->setAttribute('class', $sInputErrorClass);
+                }
+            }
+        }
+
+        // Render element
+        $sElementContent = $this->renderElement($oElement, $sLabelPosition);
+
+        // Render form row
+        switch (true) {
+            // Checkbox element not in horizontal form
+            case $sElementType === 'checkbox' && $sLayout !== Form::LAYOUT_HORIZONTAL && !$oElement->getOption('form-group'):
+
+            // All "button" elements in inline form
+            case in_array($sElementType, ['submit', 'button', 'reset'], true) && $sLayout === Form::LAYOUT_INLINE:
+                return $sElementContent . "\n";
+
+            default:
+                // Render element into form group
+                return $this->renderElementFormGroup($sElementContent, $this->getRowClassFromElement($oElement), $oElement->getOption('feedback'));
+        }
+    }
+
+    /**
+     * getRowClassFromElement 
+     * 
+     * @param ElementInterface $oElement
+     * @access public
+     * @return string
+     */
+    public function getRowClassFromElement(\Zend\Form\ElementInterface $oElement)
+    {
+        $sRowClass = '';
+
+        if ($sFormGroupSize = $oElement->getOption('twbs-form-group-size')) {
+            $sRowClass = $sFormGroupSize;
+        }
+
+        // Validation state
+        if (($sValidationState = $oElement->getOption('validation-state'))) {
+            $sRowClass .= ' has-' . $sValidationState;
+        }
+        if ($oElement->getMessages()) {
+            $sRowClass .= ' has-error';
+        }
+        if( $oElement->getOption('feedback')) {
+            $sRowClass .= ' has-feedback';
+        }
+
+        // Column size
+        if (($sColumSize = $oElement->getOption('column-size')) && $oElement->getOption('twbs-layout') !== Form::LAYOUT_HORIZONTAL
+        ) {
+            $sColumSize = (is_array($sColumSize)) ? $sColumSize : [$sColumSize];
+            $sRowClass .= implode('', array_map(function($item) { return ' col-' . $item; }, $sColumSize));
+        }
+
+        //Additional row class
+        if ($sAddRowClass = $oElement->getOption('twbs-row-class')) {
+            $sRowClass .= ' ' . $sAddRowClass;
+        }
+        return $sRowClass;
+    }
+
+
+    /**
+     * renderElementFormGroup 
+     * 
+     * @param string $sElementContent
+     * @param string $sRowClass
+     * @param string $sFeedbackElement A feedback element that should be rendered within the element, optional
+     * @access public
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function renderElementFormGroup($sElementContent, $sRowClass, $sFeedbackElement = '' )
+    {
+        if (!is_string($sElementContent)) {
+            throw new \InvalidArgumentException('Argument "$sElementContent" expects a string, "' . (is_object($sElementContent) ? get_class($sElementContent) : gettype($sElementContent)) . '" given');
+        }
+
+        if (!is_string($sRowClass)) {
+            throw new \InvalidArgumentException('Argument "$sRowClass" expects a string, "' . (is_object($sRowClass) ? get_class($sRowClass) : gettype($sRowClass)) . '" given');
+        }
+
+        if ($sFeedbackElement && !is_string($sFeedbackElement)) {
+            throw new \InvalidArgumentException('Argument "$sFeedbackElement" expects a string, "' . (is_object($sFeedbackElement) ? get_class($sFeedbackElement) : gettype($sFeedbackElement)) . '" given');
+        }
+
+        if( $sFeedbackElement ){
+            $sElementContent .= '<i class="' . $sFeedbackElement . ' form-control-feedback"></i>';
+        }
+
+        return sprintf(static::$formGroupFormat, $sRowClass, $sElementContent) . "\n";
+    }
+
+
+    /**
+     * renderLabel 
+     * Render element's label
+     * 
+     * @param ElementInterface $oElement
+     * @access protected
+     * @return string
+     */
+    protected function renderLabel(ElementInterface $oElement)
+    {
+        if (($sLabel = $oElement->getLabel()) && ($oTranslator = $this->getTranslator())) {
+            $sLabel = $oTranslator->translate($sLabel, $this->getTranslatorTextDomain());
+        }
+
+        return $sLabel;
+    }
+
+
+    /**
+     * renderElement 
+     * Render element
+     * 
+     * @param ElementInterface $oElement
+     * @param string $sLabelPosition
+     * @access protected
+     * @return type
+     * @throws DomainException
+     */
+    protected function renderElement(ElementInterface $oElement, $sLabelPosition = null)
+    {
+        // Retrieve expected layout
+        $sLayout = $oElement->getOption('twbs-layout');
+
+        // Define label position
+        if ($sLabelPosition === null) {
+            $sLabelPosition = $this->getLabelPosition();
+        }
+
+        // Render label
+        $sLabelOpen = $sLabelClose = $sLabelContent = $sElementType = '';
+
+        if ($sLabelContent = $this->renderLabel($oElement)) {
+            /*
+             * Multicheckbox elements have to be handled differently
+             * as the HTML standard does not allow nested labels.
+             * The semantic way is to group them inside a fieldset
+             */
+            $sElementType = $oElement->getAttribute('type');
+
+            // Button element is a special case, because label is always rendered inside it
+            if (($oElement instanceof Button) or ( $oElement instanceof Submit)) {
+                $sLabelContent = '';
+
+            } else {
+                $aLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
+
+                //Validation state
+                if ($oElement->getOption('validation-state') || $oElement->getMessages()) {
+                    if (empty($aLabelAttributes['class'])) {
+                        $aLabelAttributes['class'] = 'control-label';
+
+                    } elseif (!preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class']) && $sElementType !== 'checkbox') {
+                        $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' control-label');
+                    }
+                }
+
+                $oLabelHelper = $this->getLabelHelper();
+
+                switch ($sLayout) {
+                    // Hide label for "inline" layout
+                    case Form::LAYOUT_INLINE:
+                        if ($sElementType !== 'checkbox') {
+                            if ($sElementType !== 'checkbox') {
+                                if (empty($aLabelAttributes['class']) && empty($oElement->getOption('showLabel'))) {
+                                    $aLabelAttributes['class'] = 'sr-only';
+                                } elseif (empty($oElement->getOption('showLabel')) && !preg_match('/(\s|^)sr-only(\s|$)/', $aLabelAttributes['class'])) {
+                                    $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' sr-only');
+                                }
+                            }
+                        }
+                        break;
+
+                    case Form::LAYOUT_HORIZONTAL:
+                        if ($sElementType !== 'checkbox') {
+                            if (empty($aLabelAttributes['class'])) {
+                                $aLabelAttributes['class'] = 'control-label';
+                            } else {
+                                if (!preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class'])) {
+                                    $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' control-label');
+                                }
+                            }
+                        }
+                        break;
+                }
+
+                if ($aLabelAttributes) {
+                    $oElement->setLabelAttributes($aLabelAttributes);
+                }
+
+                $sLabelOpen  = $oLabelHelper->openTag($oElement->getAttribute('id') ? $oElement : $aLabelAttributes);
+                $sLabelClose = $oLabelHelper->closeTag();
+
+                // Allow label html escape desable
+                //$sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
+
+                if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+                    $sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
+                }
+            }
+        }
+
+        //Add required string if element is required
+        if ($this->requiredFormat &&
+            $oElement->getAttribute('required') &&
+            strpos($this->requiredFormat, $sLabelContent) === false
+        ) {
+            $sLabelContent .= $this->requiredFormat;
+        }
+
+        switch ($sLayout) {
+            case null:
+            case Form::LAYOUT_INLINE:
+                $sElementContent = $this->getElementHelper()->render($oElement);
+
+                // Checkbox elements are a special case, element is already rendered into label
+                if ($sElementType === 'checkbox') {
+                    $sElementContent = sprintf(static::$checkboxFormat, $sElementContent);
+                } else {
+                    if ($sLabelPosition === self::LABEL_PREPEND) {
+                        $sElementContent = $sLabelOpen . $sLabelContent . $sLabelClose . $sElementContent;
+                    } else {
+                        $sElementContent = $sElementContent . $sLabelOpen . $sLabelContent . $sLabelClose;
+                    }
+                }
+
+                // Render help block
+                $sElementContent .= $this->renderHelpBlock($oElement);
+
+                // Render errors
+                if ($this->renderErrors) {
+                    $sElementContent .= $this->getElementErrorsHelper()->render($oElement);
+                }
+
+                return $sElementContent;
+
+            case Form::LAYOUT_HORIZONTAL:
+                $sElementContent = $this->getElementHelper()->render($oElement) . $this->renderHelpBlock($oElement);
+
+                // Render errors
+                if ($this->renderErrors) {
+                    $sElementContent .= $this->getElementErrorsHelper()->render($oElement);
+                }
+
+                $sClass = '';
+
+                // Column size
+                if ($sColumSize = $oElement->getOption('column-size')) {
+                    $sClass .= ' col-' . $sColumSize;
+                }
+
+                // Checkbox elements are a special case, element is rendered into label
+                if ($sElementType === 'checkbox') {
+                    return sprintf(
+                            static::$horizontalLayoutFormat, $sClass, sprintf(static::$checkboxFormat, $sElementContent)
+                    );
+                }
+
+                if ($sLabelPosition === self::LABEL_PREPEND) {
+                    return $sLabelOpen . $sLabelContent . $sLabelClose . sprintf(
+                                    static::$horizontalLayoutFormat, $sClass, $sElementContent
+                    );
+                } else {
+                    return sprintf(
+                                    static::$horizontalLayoutFormat, $sClass, $sElementContent
+                            ) . $sLabelOpen . $sLabelContent . $sLabelClose;
+                }
+        }
+
+        throw new DomainException('Layout "' . $sLayout . '" is not valid');
+    }
+
+
+    /**
+     * renderHelpBlock 
+     * Render element's help block
+     * 
+     * @param ElementInterface $oElement
+     * @access protected
+     * @return string
+     */
+    protected function renderHelpBlock(ElementInterface $oElement)
+    {
+        if ($sHelpBlock = $oElement->getOption('help-block')) {
+            if ($oTranslator = $this->getTranslator()) {
+                $sHelpBlock = $oTranslator->translate($sHelpBlock, $this->getTranslatorTextDomain());
+            }
+
+            $sHelpBlockString = strip_tags($sHelpBlock);
+
+            if ($sHelpBlock === $sHelpBlockString) {
+                $sHelpBlock = $this->getEscapeHtmlHelper()->__invoke($sHelpBlock);
+            }
+
+            return sprintf(static::$helpBlockFormat, $sHelpBlock);
+
+        } else {
+            return '';
+        }
+    }
+}
+

--- a/src/TwbsHelper/Form/View/Helper/FormStatic.php
+++ b/src/TwbsHelper/Form/View/Helper/FormStatic.php
@@ -1,0 +1,53 @@
+<?php
+namespace TwbsHelper\Form\View\Helper;
+
+use Zend\Form\ElementInterface;
+use Zend\View\Helper\AbstractHelper;
+
+
+/**
+ * FormStatic 
+ * 
+ * @uses AbstractHelper
+ */
+class FormStatic extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    protected static $staticFormat = '<p class="form-control-static">%s</p>';
+
+
+    /**
+     * __invoke 
+     * Invoke helper as functor
+     * Proxies to {@link render()}.
+     *
+     * @param  ElementInterface|null $element
+     * @access public
+     * @return string|TwbsHelperFormStatic
+     */
+    public function __invoke(ElementInterface $element = null)
+    {
+        if (!$element) {
+            return $this;
+        }
+
+        return $this->render($element);
+    }
+
+
+    /**
+     * render 
+     * 
+     * @see \Zend\Form\View\Helper\AbstractHelper::render()
+     * @param ElementInterface $oElement
+     * @access public
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        return sprintf(static::$staticFormat, $oElement->getValue());
+    }
+}
+

--- a/src/TwbsHelper/Options/Factory/ModuleOptionsFactory.php
+++ b/src/TwbsHelper/Options/Factory/ModuleOptionsFactory.php
@@ -1,33 +1,53 @@
 <?php
-
 namespace TwbsHelper\Options\Factory;
 
-class ModuleOptionsFactory implements \Zend\ServiceManager\FactoryInterface {
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
+
+/**
+ * ModuleOptionsFactory 
+ * 
+ * @uses FactoryInterface
+ */
+class ModuleOptionsFactory implements FactoryInterface
+{
     /**
-     * @param \Zend\ServiceManager\ServiceLocatorInterface $oServiceLocator
+     * createService 
+     * 
+     * @param ServiceLocatorInterface $oServiceLocator 
+     * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function createService(\Zend\ServiceManager\ServiceLocatorInterface $oServiceLocator) {
+    public function createService(ServiceLocatorInterface $oServiceLocator) {
         return $this->createServiceWithConfig($oServiceLocator->get('config'));
     }
 
+
     /**
-     * @param \Interop\Container\ContainerInterface $oContainer
-     * @param string $sRequestedName
-     * @param array $aOptions
+     * __invoke 
+     * 
+     * @param ContainerInterface $oContainer 
+     * @param string $sRequestedName 
+     * @param array $aOptions 
+     * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function __invoke(\Interop\Container\ContainerInterface $oContainer, $sRequestedName, array $aOptions = null) {
+    public function __invoke(ContainerInterface $oContainer, $sRequestedName, array $aOptions = null) {
         return $this->createServiceWithConfig($oContainer->get('config'));
     }
 
+
     /**
-     * @param array $aConfig
+     * createServiceWithConfig 
+     * 
+     * @param array $aConfig 
+     * @access protected
      * @return \TwbsHelper\Options\ModuleOptions
      */
     protected function createServiceWithConfig(array $aConfig) {
-        return new \TwbsHelper\Options\ModuleOptions($aConfig['twbbundle']);
+        return new \TwbsHelper\Options\ModuleOptions($aConfig['twbshelper']);
     }
-
 }
+

--- a/src/TwbsHelper/Options/ModuleOptions.php
+++ b/src/TwbsHelper/Options/ModuleOptions.php
@@ -1,73 +1,98 @@
 <?php
-
 namespace TwbsHelper\Options;
 
-/**
- * Hold options for TwbsHelper module
- */
-class ModuleOptions extends \Zend\Stdlib\AbstractOptions {
+use Zend\Stdlib\AbstractOptions;
 
-    /**
-     * @var array
-     */
+
+/**
+ * ModuleOptions 
+ * Hold options for TwbsHelper module
+ * 
+ * @uses AbstractOptions
+ */
+class ModuleOptions extends AbstractOptions
+{
+    // @var array
     protected $ignoredViewHelpers;
 
-    /**
-     * @var array
-     */
+    // @var array
     protected $classMap;
 
-    /**
-     * @var array
-     */
+    // @var array
     protected $typeMap;
 
     /**
+     * getIgnoredViewHelpers 
+     * 
+     * @access public
      * @return array
      */
     public function getIgnoredViewHelpers() {
         return $this->ignoredViewHelpers;
     }
 
+
     /**
-     * @param array $aIgnoredViewHelpers
+     * setIgnoredViewHelpers 
+     * 
+     * @param array $aIgnoredViewHelpers 
+     * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
     public function setIgnoredViewHelpers(array $aIgnoredViewHelpers) {
         $this->ignoredViewHelpers = $aIgnoredViewHelpers;
+
         return $this;
     }
 
+
     /**
+     * getClassMap 
+     * 
+     * @access public
      * @return array
      */
     public function getClassMap() {
         return $this->classMap;
     }
 
+
     /**
-     * @param array $aClassMap
+     * setClassMap 
+     * 
+     * @param array $aClassMap 
+     * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
     public function setClassMap(array $aClassMap) {
         $this->classMap = $aClassMap;
+
         return $this;
     }
 
+
     /**
+     * getTypeMap 
+     * 
+     * @access public
      * @return array
      */
     public function getTypeMap() {
         return $this->typeMap;
     }
 
+
     /**
-     * @param array $aTypeMap
+     * setTypeMap 
+     * 
+     * @param array $aTypeMap 
+     * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
     public function setTypeMap(array $aTypeMap) {
         $this->typeMap = $aTypeMap;
+
         return $this;
     }
-
 }
+

--- a/src/TwbsHelper/View/Helper/ButtonGroup.php
+++ b/src/TwbsHelper/View/Helper/ButtonGroup.php
@@ -1,0 +1,141 @@
+<?php
+namespace TwbsHelper\View\Helper;
+
+use Traversable;
+use LogicException;
+use Zend\Form\View\Helper\AbstractHelper;
+use Zend\Form\ElementInterface;
+use Zend\Form\Factory;
+
+
+/**
+ * ButtonGroup 
+ * 
+ * @uses AbstractHelper
+ */
+class ButtonGroup extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    protected static $buttonGroupContainerFormat = '<div %s>%s</div>';
+
+    /**
+     * @var string
+     */
+    protected static $buttonGroupJustifiedFormat = '<div class="btn-group">%s</div>';
+
+    /**
+     * @var TwbsHelperFormElement
+     */
+    protected $formElementHelper;
+
+
+    /**
+     * __invoke 
+     * 
+     * @param  array $aButtons
+     * @param  array $aButtonGroupOptions
+     * @access public
+     * @return TwbsHelperButtonGroup|string
+     */
+    public function __invoke(array $aButtons = null, array $aButtonGroupOptions = null)
+    {
+        return $aButtons ? $this->render($aButtons, $aButtonGroupOptions) : $this;
+    }
+
+    /**
+     * Render button groups markup
+     * @param  array $aButtons
+     * @param  array $aButtonGroupOptions
+     * @throws LogicException
+     * @return string
+     */
+    public function render(array $aButtons, array $aButtonGroupOptions = null)
+    {
+        // Button group container attributes
+        if (empty($aButtonGroupOptions['attributes'])) {
+            $aButtonGroupOptions['attributes'] = ['class' => 'btn-group'];
+
+        } else {
+            if (!is_array($aButtonGroupOptions['attributes'])) {
+                throw new LogicException('"attributes" option expects an array, "' . gettype($aButtonGroupOptions['attributes']) . '" given');
+            }
+
+            if (empty($aButtonGroupOptions['attributes']['class'])) {
+                $aButtonGroupOptions['attributes']['class'] = 'btn-group';
+
+            } elseif (!preg_match('/(\s|^)(?:btn-group|btn-group-vertical)(\s|$)/', $aButtonGroupOptions['attributes']['class'])) {
+                $aButtonGroupOptions['attributes']['class'] .= ' btn-group';
+            }
+        }
+
+        // Render button group
+        return sprintf(
+            static::$buttonGroupContainerFormat,
+            //Container attributes
+            $this->createAttributesString($aButtonGroupOptions['attributes']),
+            //Buttons
+            $this->renderButtons(
+                $aButtons,
+                strpos($aButtonGroupOptions['attributes']['class'], 'btn-group-justified') !== false
+            )
+        );
+    }
+
+
+    /**
+     * renderButtons 
+     * Render buttons markup
+     * 
+     * @param  array $aButtons
+     * @access protected
+     * @return string
+     */
+    protected function renderButtons(array $aButtons, $bJustified = false)
+    {
+        $sMarkup = '';
+
+        foreach ($aButtons as $oButton) {
+            if (is_array($oButton) ||
+                ($oButton instanceof Traversable &&
+                !($oButton instanceof ElementInterface))
+            ) {
+                $oFactory = new Factory();
+                $oButton = $oFactory->create($oButton);
+
+            } elseif (!($oButton instanceof ElementInterface)) {
+                throw new LogicException(sprintf(
+                    'Button expects an instanceof Zend\Form\ElementInterface or an array / Traversable, "%s" given', is_object($oButton) ? get_class($oButton) : gettype($oButton)
+                ));
+            }
+
+            $sButtonMarkup = $this->getFormElementHelper()->__invoke($oButton);
+
+            $sMarkup .= $bJustified ? sprintf(static::$buttonGroupJustifiedFormat, $sButtonMarkup) : $sButtonMarkup;
+        }
+
+        return $sMarkup;
+    }
+
+
+    /**
+     * getFormElementHelper 
+     * 
+     * @access public
+     * @return TwbsHelperFormElement
+     */
+    public function getFormElementHelper()
+    {
+        if ($this->formElementHelper instanceof TwbsHelperFormElement) {
+            return $this->formElementHelper;
+        }
+
+        if (method_exists($this->view, 'plugin')) {
+            return $this->formElementHelper = $this->view->plugin('form_element');
+        }
+
+        return $this->formElementHelper = new TwbsHelperFormElement();
+    }
+}
+


### PR DESCRIPTION
Hi @neilime ,

first of all, let me thank you for all the work you've put into zf2-twb-bundle. I've been using it for years in some ZF2 + BS3 projects, it's an essential part of any project I work in using these frameworks.

As I'm starting to use ZF3 + BS4, I saw you early work on the new zf-twbs-helper-module, I've decided to lend a hand and contribute with the missing form view helpers. I used your zf2-twb-bundle as reference and worked out the differences based on the [Migrating to v4 Bootstrap documentation](https://getbootstrap.com/docs/4.1/migration/).

I haven't developed any unit tests for now, but I thought to perform a pull request early to speed things up and ultimately allow you to release a new version with these view helpers included. Here's a [screenshot of a demo form](https://imgur.com/a/qZbpmgr) I used during development.

I'm giving my first steps on git and github, this is actually my first contribution on someone else's project, so let me know if there's anything I should do differently.

Best regards,
Rolando Isidoro