### PR TITLE
Fix Radio and MultiCheckbox labels

### DIFF
--- a/src/TwbsHelper/Form/Element/StaticElement.php
+++ b/src/TwbsHelper/Form/Element/StaticElement.php
@@ -4,15 +4,15 @@ namespace TwbsHelper\Form\Element;
 use Zend\Form\Element as ZendElement;
 
 /**
- * StaticElement 
- * 
+ * StaticElement
+ *
  * @uses ZendElement
  */
 class StaticElement extends ZendElement
 {
     /**
      * Seed attributes
-     * 
+     *
      * @var array
      * @access protected
      */
@@ -20,4 +20,3 @@ class StaticElement extends ZendElement
         'type' => 'static'
     ];
 }
-

--- a/src/TwbsHelper/Form/View/Helper/Factory/FormElementFactory.php
+++ b/src/TwbsHelper/Form/View/Helper/Factory/FormElementFactory.php
@@ -10,20 +10,20 @@ use TwbsHelper\Form\View\Helper\FormElement;
 use TwbsHelper\Options\ModuleOptions;
 
 /**
- * FormElementFactory 
+ * FormElementFactory
  * Factory to inject the ModuleOptions hard dependency
- * 
+ *
  * @uses FactoryInterface
  */
 class FormElementFactory implements FactoryInterface
 {
     /**
-     * createService 
+     * createService
      * Compatibility with ZF2 (>= 2.2) -> proxy to __invoke
-     * 
-     * @param ServiceLocatorInterface $oServiceLocator 
-     * @param mixed $sCanonicalName 
-     * @param mixed $sRequestedName 
+     *
+     * @param ServiceLocatorInterface $oServiceLocator
+     * @param mixed $sCanonicalName
+     * @param mixed $sRequestedName
      * @access public
      * @return void
      */
@@ -34,12 +34,12 @@ class FormElementFactory implements FactoryInterface
 
 
     /**
-     * __invoke 
+     * __invoke
      * Compatibility with ZF3
-     * 
-     * @param ContainerInterface $container 
-     * @param mixed $requestedName 
-     * @param array $options 
+     *
+     * @param ContainerInterface $container
+     * @param mixed $requestedName
+     * @param array $options
      * @access public
      * @return void
      */
@@ -50,4 +50,3 @@ class FormElementFactory implements FactoryInterface
         return new FormElement($oOptions);
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/Form.php
+++ b/src/TwbsHelper/Form/View/Helper/Form.php
@@ -5,10 +5,9 @@ use Zend\Form\View\Helper\Form as ZendFormViewHelper;
 use Zend\Form\FormInterface;
 use Zend\Form\FieldsetInterface;
 
-
 /**
- * Form 
- * 
+ * Form
+ *
  * @uses ZendFormViewHelper
  */
 class Form extends ZendFormViewHelper
@@ -25,11 +24,11 @@ class Form extends ZendFormViewHelper
 
 
     /**
-     * __invoke 
-     * 
+     * __invoke
+     *
      * @see    Form::__invoke()
-     * @param  FormInterface $oForm 
-     * @param  string $sFormLayout 
+     * @param  FormInterface $oForm
+     * @param  string $sFormLayout
      * @access public
      * @return TwbsHelperForm|string
      */
@@ -46,12 +45,12 @@ class Form extends ZendFormViewHelper
 
 
     /**
-     * render 
+     * render
      * Render a form from the provided $oForm,
-     * 
+     *
      * @see    Form::render()
-     * @param  FormInterface $oForm 
-     * @param  string|null $sFormLayout 
+     * @param  FormInterface $oForm
+     * @param  string|null $sFormLayout
      * @access public
      * @return string
      */
@@ -65,7 +64,7 @@ class Form extends ZendFormViewHelper
         $this->setFormClass($oForm, $sFormLayout);
 
         // Set form role
-        if (!$oForm->getAttribute('role')) {
+        if (! $oForm->getAttribute('role')) {
             $oForm->setAttribute('role', 'form');
         }
 
@@ -74,10 +73,10 @@ class Form extends ZendFormViewHelper
 
 
     /**
-     * renderElements 
-     * 
-     * @param  FormInterface $oForm 
-     * @param  string|null $sFormLayout 
+     * renderElements
+     *
+     * @param  FormInterface $oForm
+     * @param  string|null $sFormLayout
      * @access protected
      * @return string
      */
@@ -111,7 +110,7 @@ class Form extends ZendFormViewHelper
         foreach ($oForm as $iKey => $oElement) {
             $aOptions = $oElement->getOptions();
 
-            if (!$bHasColumnSize && !empty($aOptions['column-size'])) {
+            if (! $bHasColumnSize && ! empty($aOptions['column-size'])) {
                 $bHasColumnSize = true;
             }
 
@@ -126,20 +125,17 @@ class Form extends ZendFormViewHelper
 
                 if (isset($aButtonGroups[$sButtonGroupKey])) {
                     $aButtonGroups[$sButtonGroupKey][] = $oElement;
-
                 } else {
                     $aButtonGroups[$sButtonGroupKey] = [$oElement];
                     $aElementsRendering[$iKey]       = $sButtonGroupKey;
                 }
 
-                if (!empty($aOptions['column-size']) && !isset($aButtonGroupsColumnSize[$sButtonGroupKey])) {
+                if (! empty($aOptions['column-size']) && ! isset($aButtonGroupsColumnSize[$sButtonGroupKey])) {
                     // Only the first occured column-size will be set, other are ignored.
                     $aButtonGroupsColumnSize[$sButtonGroupKey] = $aOptions['column-size'];
                 }
-
             } elseif ($oElement instanceof FieldsetInterface) {
                 $aElementsRendering[$iKey] = $oFormCollectionHelper->__invoke($oElement);
-
             } else {
                 $aElementsRendering[$iKey] = $oFormRowHelper->__invoke($oElement);
             }
@@ -156,7 +152,6 @@ class Form extends ZendFormViewHelper
                 // Render button group content
                 $options       = (isset($aButtonGroupsColumnSize[$sElementRendering])) ? ['attributes' => ['class' => 'col-' . $aButtonGroupsColumnSize[$sElementRendering]]] : null;
                 $sFormContent .= $oFormRowHelper->renderElementFormGroup($oButtonGroupHelper($aButtons, $options), $oFormRowHelper->getRowClassFromElement(current($aButtons)));
-
             } else {
                 $sFormContent .= $sElementRendering;
             }
@@ -171,11 +166,11 @@ class Form extends ZendFormViewHelper
 
 
     /**
-     * setFormClass 
+     * setFormClass
      * Sets form layout class
-     * 
-     * @param  FormInterface $oForm 
-     * @param  string|null $sFormLayout 
+     *
+     * @param  FormInterface $oForm
+     * @param  string|null $sFormLayout
      * @access protected
      * @return TwbsHelper\Form\View\Helper\TwbsHelperForm
      */
@@ -185,10 +180,9 @@ class Form extends ZendFormViewHelper
             $sLayoutClass = 'form-' . $sFormLayout;
 
             if ($sFormClass = $oForm->getAttribute('class')) {
-                if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sFormClass)) {
+                if (! preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sFormClass)) {
                     $oForm->setAttribute('class', trim($sFormClass . ' ' . $sLayoutClass));
                 }
-
             } else {
                 $oForm->setAttribute('class', $sLayoutClass);
             }
@@ -199,10 +193,10 @@ class Form extends ZendFormViewHelper
 
 
     /**
-     * openTag 
+     * openTag
      * Generate an opening form tag
-     * 
-     * @param FormInterface|null $oForm 
+     *
+     * @param FormInterface|null $oForm
      * @access public
      * @return string
      */
@@ -213,4 +207,3 @@ class Form extends ZendFormViewHelper
         return parent::openTag($oForm);
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormButton.php
+++ b/src/TwbsHelper/Form/View/Helper/FormButton.php
@@ -8,10 +8,9 @@ use Zend\Form\LabelAwareInterface;
 use Zend\Form\View\Helper\FormButton as ZendFormButtonViewHelper;
 use Zend\Form\ElementInterface;
 
-
 /**
- * FormButton 
- * 
+ * FormButton
+ *
  * @uses ZendFormButtonViewHelper
  */
 class FormButton extends ZendFormButtonViewHelper
@@ -44,8 +43,8 @@ class FormButton extends ZendFormButtonViewHelper
 
 
     /**
-     * render 
-     * 
+     * render
+     *
      * @see    FormButton::render()
      * @param  ElementInterface $oElement
      * @param  string $sButtonContent
@@ -57,13 +56,12 @@ class FormButton extends ZendFormButtonViewHelper
     {
         // Set classes assigned via attribute
         if ($sClass = $oElement->getAttribute('class')) {
-            if (!preg_match('/(\s|^)btn(\s|$)/', $sClass)) {
+            if (! preg_match('/(\s|^)btn(\s|$)/', $sClass)) {
                 $sClass .= ' btn';
             }
 
-            if (!preg_match('/(\s|^)btn-.*(\s|$)/', $sClass)) {
+            if (! preg_match('/(\s|^)btn-.*(\s|$)/', $sClass)) {
                 $sClass .= ' btn-secondary';
-
             } else {
                 $bHasOption = false;
 
@@ -74,7 +72,7 @@ class FormButton extends ZendFormButtonViewHelper
                     }
                 }
 
-                if (!$bHasOption) {
+                if (! $bHasOption) {
                     $sClass .= ' btn-secondary';
                 }
             }
@@ -88,7 +86,6 @@ class FormButton extends ZendFormButtonViewHelper
         // Retrieve icon options
         if (null !== ($aIconOptions = $oElement->getOption('glyphicon'))) {
             $sIconHelperMethod = 'glyphicon';
-
         } elseif (null !== ($aIconOptions = $oElement->getOption('fontAwesome'))) {
             $sIconHelperMethod = 'fontAwesome';
         }
@@ -97,11 +94,11 @@ class FormButton extends ZendFormButtonViewHelper
         if (null === $sButtonContent) {
             $sButtonContent = $oElement->getLabel();
 
-            if (!$sButtonContent) {
+            if (! $sButtonContent) {
                 $sButtonContent = $oElement->getValue();
             }
 
-            if (null === $sButtonContent && !$aIconOptions) {
+            if (null === $sButtonContent && ! $aIconOptions) {
                 throw new DomainException(sprintf(
                     '%s expects either button content as the second argument, ' .
                     'or that the element provided has a label value, a glyphicon option, or a fontAwesome option; none found',
@@ -115,7 +112,7 @@ class FormButton extends ZendFormButtonViewHelper
             }
         }
 
-        if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+        if (! $oElement instanceof LabelAwareInterface || ! $oElement->getLabelOption('disable_html_escape')) {
             $oEscapeHtmlHelper = $this->getEscapeHtmlHelper();
             $sButtonContent    = $oEscapeHtmlHelper($sButtonContent);
         }
@@ -131,7 +128,7 @@ class FormButton extends ZendFormButtonViewHelper
             }
 
             // Validate icon options type
-            if (!is_array($aIconOptions)) {
+            if (! is_array($aIconOptions)) {
                 throw new LogicException(sprintf(
                     '"glyphicon" and "fontAwesome" button option expects a scalar value or an array, "%s" given',
                     is_object($aIconOptions) ? get_class($aIconOptions) : gettype($aIconOptions)
@@ -141,24 +138,24 @@ class FormButton extends ZendFormButtonViewHelper
             $position = 'prepend';
 
             // Set icon position
-            if (!empty($aIconOptions['position'])) {
+            if (! empty($aIconOptions['position'])) {
                 $position = $aIconOptions['position'];
             }
 
             // Set icon
-            if (!empty($aIconOptions['icon'])) {
+            if (! empty($aIconOptions['icon'])) {
                 $icon = $aIconOptions['icon'];
             }
 
             // Validate icon option type
-            if (!is_scalar($icon)) {
+            if (! is_scalar($icon)) {
                 throw new LogicException(sprintf(
                     'Glyphicon and fontAwesome "icon" option expects a scalar value, "%s" given',
                     is_object($icon) ? get_class($icon) : gettype($icon)
                 ));
 
             // Validate icon position option type
-            } elseif (!is_string($position)) {
+            } elseif (! is_string($position)) {
                 throw new LogicException(sprintf(
                     'Glyphicon and fontAwesome "position" option expects a string, "%s" given',
                     is_object($position) ? get_class($position) : gettype($position)
@@ -202,7 +199,7 @@ class FormButton extends ZendFormButtonViewHelper
         // Dropdown button
         if ($aDropdownOptions = $oElement->getOption('dropdown')) {
             // Validate dropdown option type
-            if (!is_array($aDropdownOptions)) {
+            if (! is_array($aDropdownOptions)) {
                 throw new LogicException(sprintf(
                     '"dropdown" option expects an array, "%s" given',
                     is_object($aDropdownOptions) ? get_class($aDropdownOptions) : gettype($aDropdownOptions)
@@ -212,7 +209,7 @@ class FormButton extends ZendFormButtonViewHelper
             // Split dropdown button
             if (empty($aDropdownOptions['split'])) {
                 // Set class attribute
-                if (!preg_match('/(\s|^)dropdown-toggle(\s|$)/', $sClass = $oElement->getAttribute('class'))) {
+                if (! preg_match('/(\s|^)dropdown-toggle(\s|$)/', $sClass = $oElement->getAttribute('class'))) {
                     $oElement->setAttribute('class', trim($sClass . ' dropdown-toggle'));
                 }
 
@@ -250,4 +247,3 @@ class FormButton extends ZendFormButtonViewHelper
         return $this->openTag($oElement) . $sButtonContent . $this->closeTag();
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
@@ -9,10 +9,9 @@ use LogicException;
 use Zend\Form\Element\Checkbox;
 use Zend\Form\View\Helper\FormLabel;
 
-
 /**
- * FormCheckbox 
- * 
+ * FormCheckbox
+ *
  * @uses ZendFormCheckboxViewHelper
  */
 class FormCheckbox extends ZendFormCheckboxViewHelper
@@ -24,8 +23,8 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
 
 
     /**
-     * render 
-     * 
+     * render
+     *
      * @see    ZendFormCheckboxViewHelper::render()
      * @param  ElementInterface $oElement
      * @throws LogicException
@@ -39,7 +38,7 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
             return parent::render($oElement);
         }
 
-        if (!$oElement instanceof Checkbox) {
+        if (! $oElement instanceof Checkbox) {
             throw new InvalidArgumentException(sprintf(
                 '%s requires that the element is of type Zend\Form\Element\Checkbox',
                 __METHOD__
@@ -72,7 +71,7 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
             $aLabelAttributes = $oElement->getLabelAttributes();
 
             // Set label "for" attribute with element "id" attribute when defined
-            if (empty($aLabelAttributes['for']) && !empty($aAttributes['id'])) {
+            if (empty($aLabelAttributes['for']) && ! empty($aAttributes['id'])) {
                 $aLabelAttributes['for'] = $aAttributes['id'];
             }
 
@@ -100,15 +99,16 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
         return $sElementContent;
     }
 
-    
+
     /**
-     * getLabelContent 
-     * 
-     * @param ElementInterface $oElement 
+     * getLabelContent
+     *
+     * @param ElementInterface $oElement
      * @access public
      * @return string
      */
-    public function getLabelContent(ElementInterface $oElement){
+    public function getLabelContent(ElementInterface $oElement)
+    {
         $sLabelContent = $oElement->getLabel();
 
         if ($sLabelContent) {
@@ -122,9 +122,9 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
 
 
     /**
-     * getLabelHelper 
+     * getLabelHelper
      * Retrieve the FormLabel helper
-     * 
+     *
      * @access protected
      * @return FormLabel
      */
@@ -138,7 +138,7 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
             $this->oLabelHelper = $this->view->plugin('form_label');
         }
 
-        if (!($this->oLabelHelper instanceof FormLabel)) {
+        if (! ($this->oLabelHelper instanceof FormLabel)) {
             $this->oLabelHelper = new FormLabel();
         }
 
@@ -151,9 +151,9 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
 
 
     /**
-     * getClass 
+     * getClass
      * Return class
-     * 
+     *
      * @access protected
      * @return void
      */
@@ -162,4 +162,3 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
         return 'form-check-input';
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormCollection.php
+++ b/src/TwbsHelper/Form/View/Helper/FormCollection.php
@@ -5,10 +5,9 @@ use Zend\Form\Element\Collection as CollectionElement;
 use Zend\Form\View\Helper\FormCollection as ZendFormCollectionViewHelper;
 use Zend\Form\ElementInterface;
 
-
 /**
- * FormCollection 
- * 
+ * FormCollection
+ *
  * @uses ZendFormCollectionViewHelper
  */
 class FormCollection extends ZendFormCollectionViewHelper
@@ -27,9 +26,9 @@ class FormCollection extends ZendFormCollectionViewHelper
 
 
     /**
-     * render 
+     * render
      * Render a collection by iterating through all fieldsets and elements
-     * 
+     *
      * @param  \Zend\Form\ElementInterface $oElement
      * @access public
      * @return string
@@ -38,7 +37,7 @@ class FormCollection extends ZendFormCollectionViewHelper
     {
         $oRenderer = $this->getView();
 
-        if (!method_exists($oRenderer, 'plugin')) {
+        if (! method_exists($oRenderer, 'plugin')) {
             return '';
         }
 
@@ -60,17 +59,16 @@ class FormCollection extends ZendFormCollectionViewHelper
 
                 if ($oElementOrFieldset instanceof \Zend\Form\FieldsetInterface) {
                     $sMarkup .= $oFieldsetHelper($oElementOrFieldset);
-
                 } elseif ($oElementOrFieldset instanceof \Zend\Form\ElementInterface) {
-                	if ($oElementOrFieldset->getOption('twbs-row-open')) {
-						$sMarkup .= '<div class="row">' . "\n";
-					}
+                    if ($oElementOrFieldset->getOption('twbs-row-open')) {
+                        $sMarkup .= '<div class="row">' . "\n";
+                    }
 
-					$sMarkup .= $oElementHelper($oElementOrFieldset);
+                    $sMarkup .= $oElementHelper($oElementOrFieldset);
 
-					if ($oElementOrFieldset->getOption('twbs-row-close')) {
-						$sMarkup .= '</div>' . "\n";
-					}
+                    if ($oElementOrFieldset->getOption('twbs-row-close')) {
+                        $sMarkup .= '</div>' . "\n";
+                    }
                 }
             }
             if ($oElement instanceof \Zend\Form\Element\Collection && $oElement->shouldCreateTemplate()) {
@@ -85,7 +83,9 @@ class FormCollection extends ZendFormCollectionViewHelper
                 }
 
                 $sMarkup = sprintf(
-                    static::$legendFormat, ($sAttributes = $this->createAttributesString($oElement->getLabelAttributes()? : [])) ? ' ' . $sAttributes : '', $this->getEscapeHtmlHelper()->__invoke($sLabel)
+                    static::$legendFormat,
+                    ($sAttributes = $this->createAttributesString($oElement->getLabelAttributes() ? : [])) ? ' ' . $sAttributes : '',
+                    $this->getEscapeHtmlHelper()->__invoke($sLabel)
                 ) . $sMarkup;
             }
 
@@ -94,7 +94,7 @@ class FormCollection extends ZendFormCollectionViewHelper
                 $sLayoutClass = "form-{$sElementLayout}";
 
                 if (false != ($sElementClass = $oElement->getAttribute('class'))) {
-                    if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sElementClass)) {
+                    if (! preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sElementClass)) {
                         $oElement->setAttribute('class', trim("{$sElementClass} {$sLayoutClass}"));
                     }
                 } else {
@@ -103,17 +103,19 @@ class FormCollection extends ZendFormCollectionViewHelper
             }
 
             $sMarkup = sprintf(
-                    static::$fieldsetFormat, ($sAttributes = $this->createAttributesString($oElement->getAttributes())) ? " {$sAttributes}" : '', $sMarkup
+                static::$fieldsetFormat,
+                ($sAttributes = $this->createAttributesString($oElement->getAttributes())) ? " {$sAttributes}" : '',
+                $sMarkup
             );
         }
         return $sMarkup;
     }
 
     /**
-     * renderTemplate 
+     * renderTemplate
      * Only render a template
-     * 
-     * @param CollectionElement $collection 
+     *
+     * @param CollectionElement $collection
      * @access public
      * @return string
      */
@@ -127,4 +129,3 @@ class FormCollection extends ZendFormCollectionViewHelper
         return parent::renderTemplate($collection);
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -15,10 +15,9 @@ use Zend\Form\Element\Button;
 
 use TwbsHelper\Options\ModuleOptions;
 
-
 /**
- * FormElement 
- * 
+ * FormElement
+ *
  * @uses ZendFormElementViewHelper
  * @uses TranslatorAwareInterface
  */
@@ -61,9 +60,9 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * __construct 
-     * 
-     * @param  ModuleOptions $options 
+     * __construct
+     *
+     * @param  ModuleOptions $options
      * @access public
      * @return void
      */
@@ -82,10 +81,10 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * render 
+     * render
      * Render an element
-     * 
-     * @param  ElementInterface $oElement 
+     *
+     * @param  ElementInterface $oElement
      * @access public
      * @return string
      */
@@ -94,11 +93,11 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
         // Add form-control class
         $sElementType = $oElement->getAttribute('type');
 
-        if (!in_array($sElementType, $this->options->getIgnoredViewHelpers()) &&
-            !($oElement instanceof Collection)
+        if (! in_array($sElementType, $this->options->getIgnoredViewHelpers()) &&
+            ! ($oElement instanceof Collection)
         ) {
             if ($sElementClass = $oElement->getAttribute('class')) {
-                if (!preg_match('/(\s|^)form-control(\s|$)/', $sElementClass)) {
+                if (! preg_match('/(\s|^)form-control(\s|$)/', $sElementClass)) {
                     $oElement->setAttribute('class', trim($sElementClass . ' form-control'));
                 }
             } else {
@@ -142,11 +141,11 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * renderAddOn 
+     * renderAddOn
      * Render addo-on markup
-     * 
+     *
      * @param  ElementInterface|array|string $aAddOnOptions
-     * @param  string                        $sPosition 
+     * @param  string                        $sPosition
      * @throws InvalidArgumentException
      * @throws LogicException
      * @access protected
@@ -160,11 +159,9 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
         if ($aAddOnOptions instanceof ElementInterface) {
             $aAddOnOptions = ['element' => $aAddOnOptions];
-
         } elseif (is_scalar($aAddOnOptions)) {
             $aAddOnOptions = ['text' => $aAddOnOptions];
-
-        } elseif (!is_array($aAddOnOptions)) {
+        } elseif (! is_array($aAddOnOptions)) {
             throw new InvalidArgumentException(sprintf(
                 'Addon options expects an array or a scalar value, "%s" given',
                 is_object($aAddOnOptions) ? get_class($aAddOnOptions) : gettype($aAddOnOptions)
@@ -175,31 +172,27 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
         $sAddonTagName = 'div';
         $sAddonClass   = '';
 
-        if (!empty($aAddOnOptions['text'])) {
-            if (!is_scalar($aAddOnOptions['text'])) {
+        if (! empty($aAddOnOptions['text'])) {
+            if (! is_scalar($aAddOnOptions['text'])) {
                 throw new InvalidArgumentException(sprintf(
                     '"text" option expects a scalar value, "%s" given',
                     is_object($aAddOnOptions['text']) ? get_class($aAddOnOptions['text']) : gettype($aAddOnOptions['text'])
                 ));
-
             } elseif (($oTranslator = $this->getTranslator())) {
                 $sMarkup .= $oTranslator->translate($aAddOnOptions['text'], $this->getTranslatorTextDomain());
-
             } else {
                 $sMarkup .= $aAddOnOptions['text'];
             }
 
             $sAddonClass .= ('prepend' == $sPosition) ? ' input-group-prepend' : 'input-group-append';
-
-        } elseif (!empty($aAddOnOptions['element'])) {
+        } elseif (! empty($aAddOnOptions['element'])) {
             if (is_array($aAddOnOptions['element']) ||
                 ($aAddOnOptions['element'] instanceof Traversable &&
-                !($aAddOnOptions['element'] instanceof ElementInterface))
+                ! ($aAddOnOptions['element'] instanceof ElementInterface))
             ) {
                 $oFactory = new Factory();
                 $aAddOnOptions['element'] = $oFactory->create($aAddOnOptions['element']);
-
-            } elseif (!($aAddOnOptions['element'] instanceof ElementInterface)) {
+            } elseif (! ($aAddOnOptions['element'] instanceof ElementInterface)) {
                 throw new LogicException(sprintf(
                     '"element" option expects an instanceof Zend\Form\ElementInterface, "%s" given',
                     is_object($aAddOnOptions['element']) ? get_class($aAddOnOptions['element']) : gettype($aAddOnOptions['element'])
@@ -217,7 +210,6 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
             if ($aAddOnOptions['element'] instanceof Button) {
                 $sAddonClass .= ' input-group-btn';
                 $sAddonTagName = 'div';
-
             } else {
                 $sAddonClass .= ' input-group-addon';
             }
@@ -228,9 +220,9 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * setTranslator 
+     * setTranslator
      * Sets translator to use in helper
-     * 
+     *
      * @see    TranslatorAwareInterface::setTranslator()
      * @param  TranslatorInterface $oTranslator : [optional] translator. Default is null, which sets no translator.
      * @param  string $sTextDomain : [optional] text domain Default is null, which skips setTranslatorTextDomain
@@ -250,7 +242,7 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * getTranslator 
+     * getTranslator
      * Returns translator used in helper
      *
      * @see    TranslatorAwareInterface::getTranslator()
@@ -264,23 +256,23 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * hasTranslator 
+     * hasTranslator
      * Checks if the helper has a translator
-     * 
+     *
      * @see    TranslatorAwareInterface::hasTranslator()
      * @access public
      * @return boolean
      */
     public function hasTranslator()
     {
-        return !!$this->getTranslator();
+        return ! ! $this->getTranslator();
     }
 
 
     /**
-     * setTranslatorEnabled 
+     * setTranslatorEnabled
      * Sets whether translator is enabled and should be used
-     * 
+     *
      * @see    TranslatorAwareInterface::setTranslatorEnabled()
      * @param  boolean $bEnabled
      * @access public
@@ -288,16 +280,16 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
      */
     public function setTranslatorEnabled($bEnabled = true)
     {
-        $this->translatorEnabled = !!$bEnabled;
+        $this->translatorEnabled = ! ! $bEnabled;
 
         return $this;
     }
 
 
     /**
-     * isTranslatorEnabled 
+     * isTranslatorEnabled
      * Returns whether translator is enabled and should be used
-     * 
+     *
      * @see    TranslatorAwareInterface::isTranslatorEnabled()
      * @access public
      * @return boolean
@@ -309,9 +301,9 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * setTranslatorTextDomain 
+     * setTranslatorTextDomain
      * Set translation text domain
-     * 
+     *
      * @see    TranslatorAwareInterface::setTranslatorTextDomain()
      * @param  string $sTextDomain
      * @access public
@@ -326,9 +318,9 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
 
 
     /**
-     * getTranslatorTextDomain 
+     * getTranslatorTextDomain
      * Return the translation text domain
-     * 
+     *
      * @see    TranslatorAwareInterface::getTranslatorTextDomain()
      * @access public
      * @return string
@@ -338,4 +330,3 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
         return $this->translatorTextDomain;
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormElementErrors.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElementErrors.php
@@ -3,10 +3,9 @@ namespace TwbsHelper\Form\View\Helper;
 
 use Zend\Form\View\Helper\FormElementErrors as ZendFormElementErrorsViewHelper;
 
-
 /**
- * FormElementErrors 
- * 
+ * FormElementErrors
+ *
  * @uses ZendFormElementErrorsViewHelper
  */
 class FormElementErrors extends ZendFormElementErrorsViewHelper
@@ -15,4 +14,3 @@ class FormElementErrors extends ZendFormElementErrorsViewHelper
         'class' => 'form-text'
     ];
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormErrors.php
+++ b/src/TwbsHelper/Form/View/Helper/FormErrors.php
@@ -4,10 +4,9 @@ namespace TwbsHelper\Form\View\Helper;
 use Zend\Form\View\Helper\AbstractHelper;
 use Zend\Form\FormInterface;
 
-
 /**
- * FormErrors 
- * 
+ * FormErrors
+ *
  * @uses AbstractHelper
  */
 class FormErrors extends AbstractHelper
@@ -19,9 +18,9 @@ class FormErrors extends AbstractHelper
 
 
     /**
-     * __invoke 
+     * __invoke
      * Invoke as function
-     * 
+     *
      * @param  \Zend\Form\FormInterface $oForm
      * @param  string $sMessage
      * @param  string $bDismissable
@@ -30,15 +29,15 @@ class FormErrors extends AbstractHelper
      */
     public function __invoke(FormInterface $oForm = null, $sMessage = null, $bDismissable = false)
     {
-        if (!$oForm) {
+        if (! $oForm) {
             return $this;
         }
 
-        if (!$sMessage) {
+        if (! $sMessage) {
             $sMessage = $this->sDefaultErrorText;
         }
 
-        if ($oForm->hasValidated() && !$oForm->isValid()) {
+        if ($oForm->hasValidated() && ! $oForm->isValid()) {
             return $this->render($oForm, $sMessage, $bDismissable);
         }
 
@@ -47,9 +46,9 @@ class FormErrors extends AbstractHelper
 
 
     /**
-     * render 
+     * render
      * Renders the error messages.
-     * 
+     *
      * @param \Zend\Form\FormInterface $oForm
      * @access public
      * @return string
@@ -67,7 +66,6 @@ class FormErrors extends AbstractHelper
                         $oForm->get($fieldName)->getAttribute('id'),
                         $oForm->get($fieldName)->getLabel() . ': ' . $sFormMessage
                     );
-
                 } else {
                     $aMessages[] = $oForm->get($fieldName)->getLabel() . ': ' . $sFormMessage;
                 }
@@ -84,16 +82,15 @@ class FormErrors extends AbstractHelper
 
 
     /**
-     * dangerAlert 
+     * dangerAlert
      * Creates and returns a "danger" alert.
-     * 
+     *
      * @param string  $content
      * @param boolean $bDismissable
      * @return string
      */
     public function dangerAlert($content, $bDismissable = false)
     {
-        return $this->getView()->alert($content, array('class' => 'alert-danger'), $bDismissable);
+        return $this->getView()->alert($content, ['class' => 'alert-danger'], $bDismissable);
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormFile.php
+++ b/src/TwbsHelper/Form/View/Helper/FormFile.php
@@ -5,10 +5,9 @@ use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 use Zend\Form\View\Helper\FormInput;
 
-
 /**
- * FormFile 
- * 
+ * FormFile
+ *
  * @uses FormInput
  */
 class FormFile extends FormInput
@@ -30,7 +29,7 @@ class FormFile extends FormInput
     ];
 
     /**
-     * render 
+     * render
      * Render a form <input> element from the provided $oElement
      *
      * @param  ElementInterface $oElement
@@ -61,14 +60,13 @@ class FormFile extends FormInput
 
         if (is_array($sValue) && isset($sValue['name']) && ! is_array($sValue['name'])) {
             $aAttributes['value'] = $sValue['name'];
-
         } elseif (is_string($sValue)) {
             $aAttributes['value'] = $sValue;
         }
 
-		// Add BS4 form-control-file class if not set
-		$aAttributes['class']  = !empty($aAttributes['class']) ? $aAttributes['class'] : '';
-		$aAttributes['class'] .= (false === strpos($aAttributes['class'], 'form-control-file')) ? ' form-control-file' : '';
+        // Add BS4 form-control-file class if not set
+        $aAttributes['class']  = ! empty($aAttributes['class']) ? $aAttributes['class'] : '';
+        $aAttributes['class'] .= (false === strpos($aAttributes['class'], 'form-control-file')) ? ' form-control-file' : '';
 
         return sprintf(
             '<input %s%s',
@@ -88,4 +86,3 @@ class FormFile extends FormInput
         return 'file';
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormMultiCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormMultiCheckbox.php
@@ -5,17 +5,16 @@ use Zend\Form\Element\MultiCheckbox;
 use Zend\Form\View\Helper\FormMultiCheckbox as ZendFormMultiCheckboxViewHelper;
 use Zend\Form\ElementInterface;
 
-
 /**
- * FormMultiCheckbox 
- * 
+ * FormMultiCheckbox
+ *
  * @uses ZendFormMultiCheckboxViewHelper
  */
 class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
 {
     /**
-     * render 
-     * 
+     * render
+     *
      * @see    FormMultiCheckbox::render()
      * @param  ElementInterface $oElement
      * @access public
@@ -36,7 +35,7 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
 
 
     /**
-     * renderOptions 
+     * renderOptions
      * Render options
      *
      * @param  MultiCheckbox $oElement
@@ -45,7 +44,8 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
      * @param  array         $aAttributes
      * @return string
      */
-    protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $selectedOptions, array $aAttributes) {
+    protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $selectedOptions, array $aAttributes)
+    {
         $oEscapeHtmlHelper      = $this->getEscapeHtmlHelper();
         $oLabelHelper           = $this->getLabelHelper();
         $sLabelClose            = $oLabelHelper->closeTag();
@@ -128,7 +128,7 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
                 );
             }
 
-            if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+            if (! $oElement instanceof LabelAwareInterface || ! $oElement->getLabelOption('disable_html_escape')) {
                 $sLabel = $oEscapeHtmlHelper($sLabel);
             }
 
@@ -141,7 +141,7 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
             }
 
             // Assign label for attribute with element id attribute when defined
-            if (empty($aLabelAttributes['for']) && !empty($aInputAttributes['id'])) {
+            if (empty($aLabelAttributes['for']) && ! empty($aInputAttributes['id'])) {
                 $aLabelAttributes['for'] = $aInputAttributes['id'];
             }
 
@@ -167,4 +167,3 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
         return implode($this->getSeparator(), $aCombinedMarkup);
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormMultiCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormMultiCheckbox.php
@@ -65,11 +65,8 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
         $iCount          = 0;
 
         foreach ($aOptions as $sKey => $aOptionSpec) {
+            // Count number of options
             $iCount++;
-
-            if ($iCount > 1 && array_key_exists('id', $aAttributes)) {
-                unset($aAttributes['id']);
-            }
 
             $sValue           = '';
             $sLabel           = '';
@@ -79,6 +76,12 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
                 && $aInputAttributes['type'] != 'radio'
                 && $aInputAttributes['selected']);
             $bDisabled        = (isset($aInputAttributes['disabled']) && $aInputAttributes['disabled']);
+
+            // Customize the 'id' input attribute to enable
+            // working 'for' label attribute on all options
+            if ($iCount > 1 && array_key_exists('id', $aAttributes)) {
+                $aInputAttributes['id'] .= $iCount;
+            }
 
             if (is_scalar($aOptionSpec)) {
                 $aOptionSpec = [
@@ -140,7 +143,7 @@ class FormMultiCheckbox extends ZendFormMultiCheckboxViewHelper
                     : $aOptionSpec['label_attributes'];
             }
 
-            // Assign label for attribute with element id attribute when defined
+            // Assign label for attribute with defined element id attribute
             if (empty($aLabelAttributes['for']) && ! empty($aInputAttributes['id'])) {
                 $aLabelAttributes['for'] = $aInputAttributes['id'];
             }

--- a/src/TwbsHelper/Form/View/Helper/FormRadio.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRadio.php
@@ -5,10 +5,9 @@ use Zend\Form\View\Helper\FormRadio as ZendFormRadioViewHelper;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\MultiCheckbox;
 
-
 /**
- * FormRadio 
- * 
+ * FormRadio
+ *
  * @uses ZendFormRadioViewHelper
  */
 class FormRadio extends ZendFormRadioViewHelper
@@ -22,8 +21,8 @@ class FormRadio extends ZendFormRadioViewHelper
 
 
     /**
-     * render 
-     * 
+     * render
+     *
      * @see    \Zend\Form\View\Helper\FormRadio::render()
      * @param  \Zend\Form\ElementInterface $oElement
      * @access public
@@ -60,10 +59,10 @@ class FormRadio extends ZendFormRadioViewHelper
                 $buttonClass = $aElementOptions['btn-group']['btn-class'];
             }
 
-        	$this->setSeparator('');
-        	$oElement->setLabelAttributes(['class' => $buttonClass]);
+            $this->setSeparator('');
+            $oElement->setLabelAttributes(['class' => $buttonClass]);
 
-        	return sprintf('<div class="btn-group" data-toggle="buttons">%s</div>', parent::render($oElement));
+            return sprintf('<div class="btn-group" data-toggle="buttons">%s</div>', parent::render($oElement));
         }
 
         return sprintf(static::$checkboxFormat, parent::render($oElement));
@@ -71,8 +70,8 @@ class FormRadio extends ZendFormRadioViewHelper
 
 
     /**
-     * renderOptions 
-     * 
+     * renderOptions
+     *
      * @see    \Zend\Form\View\Helper\FormMultiCheckbox::renderOptions()
      * @param  \Zend\Form\Element\MultiCheckbox $oElement
      * @param  array $aOptions
@@ -81,7 +80,8 @@ class FormRadio extends ZendFormRadioViewHelper
      * @access protected
      * @return string
      */
-    protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $aSelectedOptions, array $aAttributes) {
+    protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $aSelectedOptions, array $aAttributes)
+    {
         $iIterator              = 0;
         $aGlobalLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
         $sMarkup                = '';
@@ -104,9 +104,9 @@ class FormRadio extends ZendFormRadioViewHelper
                 $aInputAttributes = \Zend\Stdlib\ArrayUtils::merge($aInputAttributes, $aOptionspec['attributes']);
             }
 
-			// Add BS4 form-check-input class if not set
-			$aInputAttributes['class']  = !empty($aInputAttributes['class']) ? $aInputAttributes['class'] : '';
-			$aInputAttributes['class'] .= (false === strpos($aInputAttributes['class'], 'form-check-label')) ? ' form-check-input' : '';
+            // Add BS4 form-check-input class if not set
+            $aInputAttributes['class']  = ! empty($aInputAttributes['class']) ? $aInputAttributes['class'] : '';
+            $aInputAttributes['class'] .= (false === strpos($aInputAttributes['class'], 'form-check-label')) ? ' form-check-input' : '';
 
 
             // Option value
@@ -115,18 +115,15 @@ class FormRadio extends ZendFormRadioViewHelper
             // Selected option
             if (in_array($aInputAttributes['value'], $aSelectedOptions)) {
                 $aInputAttributes['checked'] = true;
-
             } elseif (isset($aOptionspec['selected'])) {
-                $aInputAttributes['checked'] = !!$aOptionspec['selected'];
-
+                $aInputAttributes['checked'] = ! ! $aOptionspec['selected'];
             } else {
                 $aInputAttributes['checked'] = isset($aInputAttributes['selected']) && $aInputAttributes['type'] !== 'radio' && $aInputAttributes['selected'] != false;
             }
 
             // Disabled option
             if (isset($aOptionspec['disabled'])) {
-                $aInputAttributes['disabled'] = !!$aOptionspec['disabled'];
-
+                $aInputAttributes['disabled'] = ! ! $aOptionspec['disabled'];
             } else {
                 $aInputAttributes['disabled'] = isset($aInputAttributes['disabled']) && $aInputAttributes['disabled'] != false;
             }
@@ -140,14 +137,14 @@ class FormRadio extends ZendFormRadioViewHelper
             if ($sLabel) {
                 $aLabelAttributes = $aGlobalLabelAttributes;
 
-				// Add BS4 form-check-label class if not set
-				$aLabelAttributes['class']  = !empty($aLabelAttributes['class']) ? $aLabelAttributes['class'] : '';
-				$aLabelAttributes['class'] .= (false === strpos($aLabelAttributes['class'], 'form-check-label')) ? ' form-check-label' : '';
+                // Add BS4 form-check-label class if not set
+                $aLabelAttributes['class']  = ! empty($aLabelAttributes['class']) ? $aLabelAttributes['class'] : '';
+                $aLabelAttributes['class'] .= (false === strpos($aLabelAttributes['class'], 'form-check-label')) ? ' form-check-label' : '';
 
                 if (isset($aElementOptions['btn-group']) && $aElementOptions['btn-group'] == true) {
-                	if ($aInputAttributes['checked']) {
-                		$aLabelAttributes['class'] = ((isset($aLabelAttributes['class'])) ? $aLabelAttributes['class'] : '') . ' active';
-                	}
+                    if ($aInputAttributes['checked']) {
+                        $aLabelAttributes['class'] = ((isset($aLabelAttributes['class'])) ? $aLabelAttributes['class'] : '') . ' active';
+                    }
                 }
 
                 if (isset($aOptionspec['label_attributes'])) {
@@ -158,7 +155,7 @@ class FormRadio extends ZendFormRadioViewHelper
                     $sLabel = $oTranslator->translate($sLabel, $this->getTranslatorTextDomain());
                 }
 
-                if (!($oElement instanceof \Zend\Form\LabelAwareInterface) || !$oElement->getLabelOption('disable_html_escape')) {
+                if (! ($oElement instanceof \Zend\Form\LabelAwareInterface) || ! $oElement->getLabelOption('disable_html_escape')) {
                     $sLabel = $this->getEscapeHtmlHelper()->__invoke($sLabel);
                 }
 
@@ -180,4 +177,3 @@ class FormRadio extends ZendFormRadioViewHelper
         return $sMarkup;
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormRadio.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRadio.php
@@ -82,26 +82,30 @@ class FormRadio extends ZendFormRadioViewHelper
      */
     protected function renderOptions(MultiCheckbox $oElement, array $aOptions, array $aSelectedOptions, array $aAttributes)
     {
-        $iIterator              = 0;
+        $iCount                 = 0;
         $aGlobalLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
         $sMarkup                = '';
         $oLabelHelper           = $this->getLabelHelper();
         $aElementOptions        = $oElement->getOptions();
 
         foreach ($aOptions as $key => $aOptionspec) {
+            // Count number of options
+            $iCount++;
+
             if (is_scalar($aOptionspec)) {
                 $aOptionspec = ['label' => $aOptionspec, 'value' => $key];
-            }
-
-            $iIterator++;
-            if ($iIterator > 1 && array_key_exists('id', $aAttributes)) {
-                unset($aAttributes['id']);
             }
 
             // Option attributes
             $aInputAttributes = $aAttributes;
             if (isset($aOptionspec['attributes'])) {
                 $aInputAttributes = \Zend\Stdlib\ArrayUtils::merge($aInputAttributes, $aOptionspec['attributes']);
+            }
+
+            // Customize the 'id' input attribute to enable
+            // working 'for' label attribute on all options
+            if ($iCount > 1 && array_key_exists('id', $aAttributes)) {
+                $aInputAttributes['id'] .= $iCount;
             }
 
             // Add BS4 form-check-input class if not set
@@ -131,11 +135,16 @@ class FormRadio extends ZendFormRadioViewHelper
             // Render option
             $sOptionMarkup = sprintf('<input %s%s', $this->createAttributesString($aInputAttributes), $this->getInlineClosingBracket());
 
-            //Option label
+            // Option label
             $sLabel = isset($aOptionspec['label']) ? $aOptionspec['label'] : '';
 
             if ($sLabel) {
                 $aLabelAttributes = $aGlobalLabelAttributes;
+
+                // Assign label for attribute with defined element id attribute
+                if (empty($aLabelAttributes['for']) && ! empty($aInputAttributes['id'])) {
+                    $aLabelAttributes['for'] = $aInputAttributes['id'];
+                }
 
                 // Add BS4 form-check-label class if not set
                 $aLabelAttributes['class']  = ! empty($aLabelAttributes['class']) ? $aLabelAttributes['class'] : '';

--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -8,10 +8,9 @@ use Zend\Form\LabelAwareInterface;
 use Zend\Form\Element\Button;
 use Zend\Form\Element\Submit;
 
-
 /**
- * FormRow 
- * 
+ * FormRow
+ *
  * @uses ZendFormRowViewHelper
  */
 class FormRow extends ZendFormRowViewHelper
@@ -49,11 +48,11 @@ class FormRow extends ZendFormRowViewHelper
 
 
     /**
-     * render 
-     * 
+     * render
+     *
      * @see    FormRow::render()
-     * @param  ElementInterface $oElement 
-     * @param  mixed $sLabelPosition 
+     * @param  ElementInterface $oElement
+     * @param  mixed $sLabelPosition
      * @access public
      * @return string
      */
@@ -63,7 +62,7 @@ class FormRow extends ZendFormRowViewHelper
         $sElementType = $oElement->getAttribute('type');
 
         // Nothing to do for hidden elements which have no messages
-        if ('hidden' === $sElementType && !$oElement->getMessages()) {
+        if ('hidden' === $sElementType && ! $oElement->getMessages()) {
             return parent::render($oElement, $sLabelPosition);
         }
 
@@ -94,10 +93,9 @@ class FormRow extends ZendFormRowViewHelper
             //Element have errors
             if ($sInputErrorClass = $this->getInputErrorClass()) {
                 if ($sElementClass = $oElement->getAttribute('class')) {
-                    if (!preg_match('/(\s|^)' . preg_quote($sInputErrorClass, '/') . '(\s|$)/', $sElementClass)) {
+                    if (! preg_match('/(\s|^)' . preg_quote($sInputErrorClass, '/') . '(\s|$)/', $sElementClass)) {
                         $oElement->setAttribute('class', trim($sElementClass . ' ' . $sInputErrorClass));
                     }
-
                 } else {
                     $oElement->setAttribute('class', $sInputErrorClass);
                 }
@@ -110,8 +108,7 @@ class FormRow extends ZendFormRowViewHelper
         // Render form row
         switch (true) {
             // Checkbox element not in horizontal form
-            case $sElementType === 'checkbox' && $sLayout !== Form::LAYOUT_HORIZONTAL && !$oElement->getOption('form-group'):
-
+            case $sElementType === 'checkbox' && $sLayout !== Form::LAYOUT_HORIZONTAL && ! $oElement->getOption('form-group'):
             // All "button" elements in inline form
             case in_array($sElementType, ['submit', 'button', 'reset'], true) && $sLayout === Form::LAYOUT_INLINE:
                 return $sElementContent . "\n";
@@ -123,8 +120,8 @@ class FormRow extends ZendFormRowViewHelper
     }
 
     /**
-     * getRowClassFromElement 
-     * 
+     * getRowClassFromElement
+     *
      * @param ElementInterface $oElement
      * @access public
      * @return string
@@ -144,7 +141,7 @@ class FormRow extends ZendFormRowViewHelper
         if ($oElement->getMessages()) {
             $sRowClass .= ' has-error';
         }
-        if( $oElement->getOption('feedback')) {
+        if ($oElement->getOption('feedback')) {
             $sRowClass .= ' has-feedback';
         }
 
@@ -152,7 +149,9 @@ class FormRow extends ZendFormRowViewHelper
         if (($sColumSize = $oElement->getOption('column-size')) && $oElement->getOption('twbs-layout') !== Form::LAYOUT_HORIZONTAL
         ) {
             $sColumSize = (is_array($sColumSize)) ? $sColumSize : [$sColumSize];
-            $sRowClass .= implode('', array_map(function($item) { return ' col-' . $item; }, $sColumSize));
+            $sRowClass .= implode('', array_map(function ($item) {
+                return ' col-' . $item;
+            }, $sColumSize));
         }
 
         //Additional row class
@@ -164,8 +163,8 @@ class FormRow extends ZendFormRowViewHelper
 
 
     /**
-     * renderElementFormGroup 
-     * 
+     * renderElementFormGroup
+     *
      * @param string $sElementContent
      * @param string $sRowClass
      * @param string $sFeedbackElement A feedback element that should be rendered within the element, optional
@@ -173,21 +172,21 @@ class FormRow extends ZendFormRowViewHelper
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function renderElementFormGroup($sElementContent, $sRowClass, $sFeedbackElement = '' )
+    public function renderElementFormGroup($sElementContent, $sRowClass, $sFeedbackElement = '')
     {
-        if (!is_string($sElementContent)) {
+        if (! is_string($sElementContent)) {
             throw new \InvalidArgumentException('Argument "$sElementContent" expects a string, "' . (is_object($sElementContent) ? get_class($sElementContent) : gettype($sElementContent)) . '" given');
         }
 
-        if (!is_string($sRowClass)) {
+        if (! is_string($sRowClass)) {
             throw new \InvalidArgumentException('Argument "$sRowClass" expects a string, "' . (is_object($sRowClass) ? get_class($sRowClass) : gettype($sRowClass)) . '" given');
         }
 
-        if ($sFeedbackElement && !is_string($sFeedbackElement)) {
+        if ($sFeedbackElement && ! is_string($sFeedbackElement)) {
             throw new \InvalidArgumentException('Argument "$sFeedbackElement" expects a string, "' . (is_object($sFeedbackElement) ? get_class($sFeedbackElement) : gettype($sFeedbackElement)) . '" given');
         }
 
-        if( $sFeedbackElement ){
+        if ($sFeedbackElement) {
             $sElementContent .= '<i class="' . $sFeedbackElement . ' form-control-feedback"></i>';
         }
 
@@ -196,9 +195,9 @@ class FormRow extends ZendFormRowViewHelper
 
 
     /**
-     * renderLabel 
+     * renderLabel
      * Render element's label
-     * 
+     *
      * @param ElementInterface $oElement
      * @access protected
      * @return string
@@ -214,9 +213,9 @@ class FormRow extends ZendFormRowViewHelper
 
 
     /**
-     * renderElement 
+     * renderElement
      * Render element
-     * 
+     *
      * @param ElementInterface $oElement
      * @param string $sLabelPosition
      * @access protected
@@ -247,7 +246,6 @@ class FormRow extends ZendFormRowViewHelper
             // Button element is a special case, because label is always rendered inside it
             if (($oElement instanceof Button) or ( $oElement instanceof Submit)) {
                 $sLabelContent = '';
-
             } else {
                 $aLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
 
@@ -255,8 +253,7 @@ class FormRow extends ZendFormRowViewHelper
                 if ($oElement->getOption('validation-state') || $oElement->getMessages()) {
                     if (empty($aLabelAttributes['class'])) {
                         $aLabelAttributes['class'] = 'control-label';
-
-                    } elseif (!preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class']) && $sElementType !== 'checkbox') {
+                    } elseif (! preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class']) && $sElementType !== 'checkbox') {
                         $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' control-label');
                     }
                 }
@@ -270,7 +267,7 @@ class FormRow extends ZendFormRowViewHelper
                             if ($sElementType !== 'checkbox') {
                                 if (empty($aLabelAttributes['class']) && empty($oElement->getOption('showLabel'))) {
                                     $aLabelAttributes['class'] = 'sr-only';
-                                } elseif (empty($oElement->getOption('showLabel')) && !preg_match('/(\s|^)sr-only(\s|$)/', $aLabelAttributes['class'])) {
+                                } elseif (empty($oElement->getOption('showLabel')) && ! preg_match('/(\s|^)sr-only(\s|$)/', $aLabelAttributes['class'])) {
                                     $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' sr-only');
                                 }
                             }
@@ -282,7 +279,7 @@ class FormRow extends ZendFormRowViewHelper
                             if (empty($aLabelAttributes['class'])) {
                                 $aLabelAttributes['class'] = 'control-label';
                             } else {
-                                if (!preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class'])) {
+                                if (! preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class'])) {
                                     $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' control-label');
                                 }
                             }
@@ -300,7 +297,7 @@ class FormRow extends ZendFormRowViewHelper
                 // Allow label html escape desable
                 //$sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
 
-                if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+                if (! $oElement instanceof LabelAwareInterface || ! $oElement->getLabelOption('disable_html_escape')) {
                     $sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
                 }
             }
@@ -358,18 +355,24 @@ class FormRow extends ZendFormRowViewHelper
                 // Checkbox elements are a special case, element is rendered into label
                 if ($sElementType === 'checkbox') {
                     return sprintf(
-                            static::$horizontalLayoutFormat, $sClass, sprintf(static::$checkboxFormat, $sElementContent)
+                        static::$horizontalLayoutFormat,
+                        $sClass,
+                        sprintf(static::$checkboxFormat, $sElementContent)
                     );
                 }
 
                 if ($sLabelPosition === self::LABEL_PREPEND) {
                     return $sLabelOpen . $sLabelContent . $sLabelClose . sprintf(
-                                    static::$horizontalLayoutFormat, $sClass, $sElementContent
+                        static::$horizontalLayoutFormat,
+                        $sClass,
+                        $sElementContent
                     );
                 } else {
                     return sprintf(
-                                    static::$horizontalLayoutFormat, $sClass, $sElementContent
-                            ) . $sLabelOpen . $sLabelContent . $sLabelClose;
+                        static::$horizontalLayoutFormat,
+                        $sClass,
+                        $sElementContent
+                    ) . $sLabelOpen . $sLabelContent . $sLabelClose;
                 }
         }
 
@@ -378,9 +381,9 @@ class FormRow extends ZendFormRowViewHelper
 
 
     /**
-     * renderHelpBlock 
+     * renderHelpBlock
      * Render element's help block
-     * 
+     *
      * @param ElementInterface $oElement
      * @access protected
      * @return string
@@ -399,10 +402,8 @@ class FormRow extends ZendFormRowViewHelper
             }
 
             return sprintf(static::$helpBlockFormat, $sHelpBlock);
-
         } else {
             return '';
         }
     }
 }
-

--- a/src/TwbsHelper/Form/View/Helper/FormStatic.php
+++ b/src/TwbsHelper/Form/View/Helper/FormStatic.php
@@ -4,10 +4,9 @@ namespace TwbsHelper\Form\View\Helper;
 use Zend\Form\ElementInterface;
 use Zend\View\Helper\AbstractHelper;
 
-
 /**
- * FormStatic 
- * 
+ * FormStatic
+ *
  * @uses AbstractHelper
  */
 class FormStatic extends AbstractHelper
@@ -19,7 +18,7 @@ class FormStatic extends AbstractHelper
 
 
     /**
-     * __invoke 
+     * __invoke
      * Invoke helper as functor
      * Proxies to {@link render()}.
      *
@@ -29,7 +28,7 @@ class FormStatic extends AbstractHelper
      */
     public function __invoke(ElementInterface $element = null)
     {
-        if (!$element) {
+        if (! $element) {
             return $this;
         }
 
@@ -38,8 +37,8 @@ class FormStatic extends AbstractHelper
 
 
     /**
-     * render 
-     * 
+     * render
+     *
      * @see \Zend\Form\View\Helper\AbstractHelper::render()
      * @param ElementInterface $oElement
      * @access public
@@ -50,4 +49,3 @@ class FormStatic extends AbstractHelper
         return sprintf(static::$staticFormat, $oElement->getValue());
     }
 }
-

--- a/src/TwbsHelper/Module.php
+++ b/src/TwbsHelper/Module.php
@@ -2,14 +2,15 @@
 
 namespace TwbsHelper;
 
-class Module implements \Zend\ModuleManager\Feature\ConfigProviderInterface {
+class Module implements \Zend\ModuleManager\Feature\ConfigProviderInterface
+{
 
     /**
      * Retrieve module configuration
      * @return array The configuration array
      */
-    public function getConfig() {
+    public function getConfig()
+    {
         return include __DIR__ . DIRECTORY_SEPARATOR . '/../../config/module.config.php';
     }
-
 }

--- a/src/TwbsHelper/Options/Factory/ModuleOptionsFactory.php
+++ b/src/TwbsHelper/Options/Factory/ModuleOptionsFactory.php
@@ -5,49 +5,50 @@ use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-
 /**
- * ModuleOptionsFactory 
- * 
+ * ModuleOptionsFactory
+ *
  * @uses FactoryInterface
  */
 class ModuleOptionsFactory implements FactoryInterface
 {
     /**
-     * createService 
-     * 
-     * @param ServiceLocatorInterface $oServiceLocator 
+     * createService
+     *
+     * @param ServiceLocatorInterface $oServiceLocator
      * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function createService(ServiceLocatorInterface $oServiceLocator) {
+    public function createService(ServiceLocatorInterface $oServiceLocator)
+    {
         return $this->createServiceWithConfig($oServiceLocator->get('config'));
     }
 
 
     /**
-     * __invoke 
-     * 
-     * @param ContainerInterface $oContainer 
-     * @param string $sRequestedName 
-     * @param array $aOptions 
+     * __invoke
+     *
+     * @param ContainerInterface $oContainer
+     * @param string $sRequestedName
+     * @param array $aOptions
      * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function __invoke(ContainerInterface $oContainer, $sRequestedName, array $aOptions = null) {
+    public function __invoke(ContainerInterface $oContainer, $sRequestedName, array $aOptions = null)
+    {
         return $this->createServiceWithConfig($oContainer->get('config'));
     }
 
 
     /**
-     * createServiceWithConfig 
-     * 
-     * @param array $aConfig 
+     * createServiceWithConfig
+     *
+     * @param array $aConfig
      * @access protected
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    protected function createServiceWithConfig(array $aConfig) {
+    protected function createServiceWithConfig(array $aConfig)
+    {
         return new \TwbsHelper\Options\ModuleOptions($aConfig['twbshelper']);
     }
 }
-

--- a/src/TwbsHelper/Options/ModuleOptions.php
+++ b/src/TwbsHelper/Options/ModuleOptions.php
@@ -3,11 +3,10 @@ namespace TwbsHelper\Options;
 
 use Zend\Stdlib\AbstractOptions;
 
-
 /**
- * ModuleOptions 
+ * ModuleOptions
  * Hold options for TwbsHelper module
- * 
+ *
  * @uses AbstractOptions
  */
 class ModuleOptions extends AbstractOptions
@@ -22,24 +21,26 @@ class ModuleOptions extends AbstractOptions
     protected $typeMap;
 
     /**
-     * getIgnoredViewHelpers 
-     * 
+     * getIgnoredViewHelpers
+     *
      * @access public
      * @return array
      */
-    public function getIgnoredViewHelpers() {
+    public function getIgnoredViewHelpers()
+    {
         return $this->ignoredViewHelpers;
     }
 
 
     /**
-     * setIgnoredViewHelpers 
-     * 
-     * @param array $aIgnoredViewHelpers 
+     * setIgnoredViewHelpers
+     *
+     * @param array $aIgnoredViewHelpers
      * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function setIgnoredViewHelpers(array $aIgnoredViewHelpers) {
+    public function setIgnoredViewHelpers(array $aIgnoredViewHelpers)
+    {
         $this->ignoredViewHelpers = $aIgnoredViewHelpers;
 
         return $this;
@@ -47,24 +48,26 @@ class ModuleOptions extends AbstractOptions
 
 
     /**
-     * getClassMap 
-     * 
+     * getClassMap
+     *
      * @access public
      * @return array
      */
-    public function getClassMap() {
+    public function getClassMap()
+    {
         return $this->classMap;
     }
 
 
     /**
-     * setClassMap 
-     * 
-     * @param array $aClassMap 
+     * setClassMap
+     *
+     * @param array $aClassMap
      * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function setClassMap(array $aClassMap) {
+    public function setClassMap(array $aClassMap)
+    {
         $this->classMap = $aClassMap;
 
         return $this;
@@ -72,27 +75,28 @@ class ModuleOptions extends AbstractOptions
 
 
     /**
-     * getTypeMap 
-     * 
+     * getTypeMap
+     *
      * @access public
      * @return array
      */
-    public function getTypeMap() {
+    public function getTypeMap()
+    {
         return $this->typeMap;
     }
 
 
     /**
-     * setTypeMap 
-     * 
-     * @param array $aTypeMap 
+     * setTypeMap
+     *
+     * @param array $aTypeMap
      * @access public
      * @return \TwbsHelper\Options\ModuleOptions
      */
-    public function setTypeMap(array $aTypeMap) {
+    public function setTypeMap(array $aTypeMap)
+    {
         $this->typeMap = $aTypeMap;
 
         return $this;
     }
 }
-

--- a/src/TwbsHelper/View/Helper/Abbreviation.php
+++ b/src/TwbsHelper/View/Helper/Abbreviation.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for rendering abbreviations
  */
-class Abbreviation extends \Zend\View\Helper\AbstractHtmlElement {
+class Abbreviation extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     /**
      * Generates an 'abbreviation' element
@@ -18,17 +19,18 @@ class Abbreviation extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The abbreviation XHTML.
      * @throws \InvalidArgumentException
      */
-    public function __invoke($sContent, $sTitle = '', $bInitialism = false, array $aAttributes = array(), $bEscape = true) {
-        if (!is_string($sContent)) {
+    public function __invoke($sContent, $sTitle = '', $bInitialism = false, array $aAttributes = [], $bEscape = true)
+    {
+        if (! is_string($sContent)) {
             throw new \InvalidArgumentException('Argument "$sContent" expects a string, "' . (is_object($sContent) ? get_class($sContent) : gettype($sContent)) . '" given');
         }
-        if (!is_string($sTitle)) {
+        if (! is_string($sTitle)) {
             throw new \InvalidArgumentException('Argument "$sTitle" expects a string, "' . (is_object($sTitle) ? get_class($sTitle) : gettype($sTitle)) . '" given');
         }
-        if (!is_bool($bInitialism)) {
+        if (! is_bool($bInitialism)) {
             throw new \InvalidArgumentException('Argument "$bInitialism" expects a boolean, "' . (is_object($bInitialism) ? get_class($bInitialism) : gettype($bInitialism)) . '" given');
         }
-        if (!is_bool($bEscape)) {
+        if (! is_bool($bEscape)) {
             throw new \InvalidArgumentException('Argument "$bEscape" expects a boolean, "' . (is_object($bEscape) ? get_class($bEscape) : gettype($bEscape)) . '" given');
         }
 
@@ -49,5 +51,4 @@ class Abbreviation extends \Zend\View\Helper\AbstractHtmlElement {
 
         return '<abbr' . ($aAttributes ? $this->htmlAttribs($aAttributes) : '') . '>' . $sContent . '</abbr>';
     }
-
 }

--- a/src/TwbsHelper/View/Helper/Alert.php
+++ b/src/TwbsHelper/View/Helper/Alert.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for rendering alerts
  */
-class Alert extends \Zend\View\Helper\AbstractHtmlElement {
+class Alert extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     /**
      * Generates an 'alert' element
@@ -18,17 +19,18 @@ class Alert extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The alert XHTML.
      * @throws \InvalidArgumentException
      */
-    public function __invoke($sContent, $sType = '', $bDismissible = false, array $aAttributes = array(), $bEscape = true) {
-        if (!is_string($sContent)) {
+    public function __invoke($sContent, $sType = '', $bDismissible = false, array $aAttributes = [], $bEscape = true)
+    {
+        if (! is_string($sContent)) {
             throw new \InvalidArgumentException('Argument "$sContent" expects a string, "' . (is_object($sContent) ? get_class($sContent) : gettype($sContent)) . '" given');
         }
-        if (!is_string($sType)) {
+        if (! is_string($sType)) {
             throw new \InvalidArgumentException('Argument "$sType" expects a string, "' . (is_object($sType) ? get_class($sType) : gettype($sType)) . '" given');
         }
-        if (!is_bool($bDismissible)) {
+        if (! is_bool($bDismissible)) {
             throw new \InvalidArgumentException('Argument "$bDismissible" expects a boolean, "' . (is_object($bDismissible) ? get_class($bDismissible) : gettype($bDismissible)) . '" given');
         }
-        if (!is_bool($bEscape)) {
+        if (! is_bool($bEscape)) {
             throw new \InvalidArgumentException('Argument "$bEscape" expects a boolean, "' . (is_object($bEscape) ? get_class($bEscape) : gettype($bEscape)) . '" given');
         }
 
@@ -57,5 +59,4 @@ class Alert extends \Zend\View\Helper\AbstractHtmlElement {
         }
         return '<div' . ($aAttributes ? $this->htmlAttribs($aAttributes) : '') . '>' . PHP_EOL . $sDismissibleButton . '    ' . $sContent . PHP_EOL . '</div>';
     }
-
 }

--- a/src/TwbsHelper/View/Helper/Badge.php
+++ b/src/TwbsHelper/View/Helper/Badge.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for rendering badges
  */
-class Badge extends \Zend\View\Helper\AbstractHtmlElement {
+class Badge extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     /**
      * Generates a 'badge' element
@@ -18,17 +19,18 @@ class Badge extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The badge XHTML.
      * @throws \InvalidArgumentException
      */
-    public function __invoke($sContent, $sType = 'default', $bPill = false, array $aAttributes = array(), $bEscape = true) {
-        if (!is_string($sContent)) {
+    public function __invoke($sContent, $sType = 'default', $bPill = false, array $aAttributes = [], $bEscape = true)
+    {
+        if (! is_string($sContent)) {
             throw new \InvalidArgumentException('Argument "$sContent" expects a string, "' . (is_object($sContent) ? get_class($sContent) : gettype($sContent)) . '" given');
         }
-        if (!is_string($sType)) {
+        if (! is_string($sType)) {
             throw new \InvalidArgumentException('Argument "$sType" expects a string, "' . (is_object($sType) ? get_class($sType) : gettype($sType)) . '" given');
         }
-        if (!is_bool($bPill)) {
+        if (! is_bool($bPill)) {
             throw new \InvalidArgumentException('Argument "$bPill" expects a boolean, "' . (is_object($bPill) ? get_class($bPill) : gettype($bPill)) . '" given');
         }
-        if (!is_bool($bEscape)) {
+        if (! is_bool($bEscape)) {
             throw new \InvalidArgumentException('Argument "$bEscape" expects a boolean, "' . (is_object($bEscape) ? get_class($bEscape) : gettype($bEscape)) . '" given');
         }
 
@@ -50,5 +52,4 @@ class Badge extends \Zend\View\Helper\AbstractHtmlElement {
         }
         return '<span' . ($aAttributes ? $this->htmlAttribs($aAttributes) : '') . '>' . $sContent . '</span>';
     }
-
 }

--- a/src/TwbsHelper/View/Helper/Blockquote.php
+++ b/src/TwbsHelper/View/Helper/Blockquote.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for rendering blockquotes
  */
-class Blockquote extends \Zend\View\Helper\AbstractHtmlElement {
+class Blockquote extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     /**
      * Generates a 'blockquote' element
@@ -19,14 +20,15 @@ class Blockquote extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The blockquote XHTML.
      * @throws \InvalidArgumentException
      */
-    public function __invoke($sContent, $sFooter = '', array $aAttributes = array(), array $aContentAttributes = array(), array $aFooterAttributes = array(), $bEscape = true) {
-        if (!is_string($sContent)) {
+    public function __invoke($sContent, $sFooter = '', array $aAttributes = [], array $aContentAttributes = [], array $aFooterAttributes = [], $bEscape = true)
+    {
+        if (! is_string($sContent)) {
             throw new \InvalidArgumentException('Argument "$sContent" expects a string, "' . (is_object($sContent) ? get_class($sContent) : gettype($sContent)) . '" given');
         }
-        if (!is_string($sFooter)) {
+        if (! is_string($sFooter)) {
             throw new \InvalidArgumentException('Argument "$sFooter" expects a string, "' . (is_object($sFooter) ? get_class($sFooter) : gettype($sFooter)) . '" given');
         }
-        if (!is_bool($bEscape)) {
+        if (! is_bool($bEscape)) {
             throw new \InvalidArgumentException('Argument "$bEscape" expects a boolean, "' . (is_object($bEscape) ? get_class($bEscape) : gettype($bEscape)) . '" given');
         }
 
@@ -67,5 +69,4 @@ class Blockquote extends \Zend\View\Helper\AbstractHtmlElement {
                 ($sFooter ? '    <footer' . ($aFooterAttributes ? $this->htmlAttribs($aFooterAttributes) : '') . '>' . $sFooter . '</footer>' . PHP_EOL : '') .
                 '</blockquote>';
     }
-
 }

--- a/src/TwbsHelper/View/Helper/ButtonGroup.php
+++ b/src/TwbsHelper/View/Helper/ButtonGroup.php
@@ -7,10 +7,9 @@ use Zend\Form\View\Helper\AbstractHelper;
 use Zend\Form\ElementInterface;
 use Zend\Form\Factory;
 
-
 /**
- * ButtonGroup 
- * 
+ * ButtonGroup
+ *
  * @uses AbstractHelper
  */
 class ButtonGroup extends AbstractHelper
@@ -32,8 +31,8 @@ class ButtonGroup extends AbstractHelper
 
 
     /**
-     * __invoke 
-     * 
+     * __invoke
+     *
      * @param  array $aButtons
      * @param  array $aButtonGroupOptions
      * @access public
@@ -56,16 +55,14 @@ class ButtonGroup extends AbstractHelper
         // Button group container attributes
         if (empty($aButtonGroupOptions['attributes'])) {
             $aButtonGroupOptions['attributes'] = ['class' => 'btn-group'];
-
         } else {
-            if (!is_array($aButtonGroupOptions['attributes'])) {
+            if (! is_array($aButtonGroupOptions['attributes'])) {
                 throw new LogicException('"attributes" option expects an array, "' . gettype($aButtonGroupOptions['attributes']) . '" given');
             }
 
             if (empty($aButtonGroupOptions['attributes']['class'])) {
                 $aButtonGroupOptions['attributes']['class'] = 'btn-group';
-
-            } elseif (!preg_match('/(\s|^)(?:btn-group|btn-group-vertical)(\s|$)/', $aButtonGroupOptions['attributes']['class'])) {
+            } elseif (! preg_match('/(\s|^)(?:btn-group|btn-group-vertical)(\s|$)/', $aButtonGroupOptions['attributes']['class'])) {
                 $aButtonGroupOptions['attributes']['class'] .= ' btn-group';
             }
         }
@@ -85,9 +82,9 @@ class ButtonGroup extends AbstractHelper
 
 
     /**
-     * renderButtons 
+     * renderButtons
      * Render buttons markup
-     * 
+     *
      * @param  array $aButtons
      * @access protected
      * @return string
@@ -99,14 +96,14 @@ class ButtonGroup extends AbstractHelper
         foreach ($aButtons as $oButton) {
             if (is_array($oButton) ||
                 ($oButton instanceof Traversable &&
-                !($oButton instanceof ElementInterface))
+                ! ($oButton instanceof ElementInterface))
             ) {
                 $oFactory = new Factory();
                 $oButton = $oFactory->create($oButton);
-
-            } elseif (!($oButton instanceof ElementInterface)) {
+            } elseif (! ($oButton instanceof ElementInterface)) {
                 throw new LogicException(sprintf(
-                    'Button expects an instanceof Zend\Form\ElementInterface or an array / Traversable, "%s" given', is_object($oButton) ? get_class($oButton) : gettype($oButton)
+                    'Button expects an instanceof Zend\Form\ElementInterface or an array / Traversable, "%s" given',
+                    is_object($oButton) ? get_class($oButton) : gettype($oButton)
                 ));
             }
 
@@ -120,8 +117,8 @@ class ButtonGroup extends AbstractHelper
 
 
     /**
-     * getFormElementHelper 
-     * 
+     * getFormElementHelper
+     *
      * @access public
      * @return TwbsHelperFormElement
      */
@@ -138,4 +135,3 @@ class ButtonGroup extends AbstractHelper
         return $this->formElementHelper = new TwbsHelperFormElement();
     }
 }
-

--- a/src/TwbsHelper/View/Helper/Figure.php
+++ b/src/TwbsHelper/View/Helper/Figure.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for rendering figures
  */
-class Figure extends \Zend\View\Helper\AbstractHtmlElement {
+class Figure extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     /**
      * Generates a 'figure' element
@@ -19,14 +20,15 @@ class Figure extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The figure XHTML.
      * @throws \InvalidArgumentException
      */
-    public function __invoke($sImageSrc, $sCaption = '', array $aAttributes = array(), array $aImageAttributes = array(), array $aCaptionAttributes = array(), $bEscape = true) {
-        if (!is_string($sImageSrc)) {
+    public function __invoke($sImageSrc, $sCaption = '', array $aAttributes = [], array $aImageAttributes = [], array $aCaptionAttributes = [], $bEscape = true)
+    {
+        if (! is_string($sImageSrc)) {
             throw new \InvalidArgumentException('Argument "$sImageSrc" expects a string, "' . (is_object($sImageSrc) ? get_class($sImageSrc) : gettype($sImageSrc)) . '" given');
         }
-        if (!is_string($sCaption)) {
+        if (! is_string($sCaption)) {
             throw new \InvalidArgumentException('Argument "$sCaption" expects a string, "' . (is_object($sCaption) ? get_class($sCaption) : gettype($sCaption)) . '" given');
         }
-        if (!is_bool($bEscape)) {
+        if (! is_bool($bEscape)) {
             throw new \InvalidArgumentException('Argument "$bEscape" expects a boolean, "' . (is_object($bEscape) ? get_class($bEscape) : gettype($bEscape)) . '" given');
         }
 
@@ -63,5 +65,4 @@ class Figure extends \Zend\View\Helper\AbstractHtmlElement {
                 ($sCaption ? '    <figcaption' . ($aCaptionAttributes ? $this->htmlAttribs($aCaptionAttributes) : '') . '>' . $sCaption . '</figcaption>' . PHP_EOL : '') .
                 '</figure>';
     }
-
 }

--- a/src/TwbsHelper/View/Helper/HtmlList.php
+++ b/src/TwbsHelper/View/Helper/HtmlList.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for ordered and unordered lists
  */
-class HtmlList extends \Zend\View\Helper\AbstractHtmlElement {
+class HtmlList extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     /**
      * Generates a 'List' element. Manage indentation of Xhtml markup
@@ -17,14 +18,15 @@ class HtmlList extends \Zend\View\Helper\AbstractHtmlElement {
      * @throws \InvalidArgumentException
      * @return string The list XHTML.
      */
-    public function __invoke(array $aItems, $bOrdered = false, $aAttributes = false, $bEscape = true) {
+    public function __invoke(array $aItems, $bOrdered = false, $aAttributes = false, $bEscape = true)
+    {
         if (empty($aItems)) {
             throw new \InvalidArgumentException('Argument "$aItems" must not be empty');
         }
-        if (!is_bool($bOrdered)) {
+        if (! is_bool($bOrdered)) {
             throw new \InvalidArgumentException('Argument "$bOrdered" expects a boolean, "' . (is_object($bOrdered) ? get_class($bOrdered) : gettype($bOrdered)) . '" given');
         }
-        if (!is_bool($bEscape)) {
+        if (! is_bool($bEscape)) {
             throw new \InvalidArgumentException('Argument "$bEscape" expects a boolean, "' . (is_object($bEscape) ? get_class($bEscape) : gettype($bEscape)) . '" given');
         }
 
@@ -38,18 +40,18 @@ class HtmlList extends \Zend\View\Helper\AbstractHtmlElement {
                 $iNestedLevel = 0;
             }
             $sUlAttributes = $this->htmlAttribs($aAttributes);
-            $sLiAttributes = isset($aAttributes['class']) && strpos($aAttributes['class'], 'list-inline') !== false ? $this->htmlAttribs(array('class' => 'list-inline-item',)) : '';
+            $sLiAttributes = isset($aAttributes['class']) && strpos($aAttributes['class'], 'list-inline') !== false ? $this->htmlAttribs(['class' => 'list-inline-item',]) : '';
         } else {
             $sUlAttributes = $sLiAttributes = '';
             $iNestedLevel = 0;
-            $aAttributes = array();
+            $aAttributes = [];
         }
 
 
         foreach ($aItems as $sItem) {
             $iNestedLevel++;
             $sItemIndentation = str_repeat(' ', $iNestedLevel * 4);
-            if (!is_array($sItem)) {
+            if (! is_array($sItem)) {
                 if ($bEscape) {
                     $oEscaper = $this->getView()->plugin('escapeHtml');
                     $sItem = $oEscaper($sItem);
@@ -60,7 +62,7 @@ class HtmlList extends \Zend\View\Helper\AbstractHtmlElement {
                 $iItemLength = 5 + strlen(PHP_EOL);
 
                 // Generate nested list
-                $sNestedList = PHP_EOL . $this($sItem, $bOrdered, array_merge($aAttributes, array('nested_level' => $iNestedLevel + 1)), $bEscape) . $sItemIndentation . '</li>' . PHP_EOL;
+                $sNestedList = PHP_EOL . $this($sItem, $bOrdered, array_merge($aAttributes, ['nested_level' => $iNestedLevel + 1]), $bEscape) . $sItemIndentation . '</li>' . PHP_EOL;
 
                 if ($iItemLength < strlen($sList)) {
                     $sList = substr($sList, 0, strlen($sList) - $iItemLength) . $sNestedList;
@@ -75,5 +77,4 @@ class HtmlList extends \Zend\View\Helper\AbstractHtmlElement {
         $sIndentation = str_repeat(' ', $iNestedLevel * 4);
         return $sIndentation . '<' . $sTag . ($sUlAttributes ?: '') . '>' . PHP_EOL . $sList . $sIndentation . '</' . $sTag . '>' . PHP_EOL;
     }
-
 }

--- a/src/TwbsHelper/View/Helper/Table.php
+++ b/src/TwbsHelper/View/Helper/Table.php
@@ -5,7 +5,8 @@ namespace TwbsHelper\View\Helper;
 /**
  * Helper for rendering tables
  */
-class Table extends \Zend\View\Helper\AbstractHtmlElement {
+class Table extends \Zend\View\Helper\AbstractHtmlElement
+{
 
     const TABLE_HEAD = 'thead';
     const TABLE_BODY = 'tbody';
@@ -22,7 +23,8 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The table XHTML.
      * @throws \InvalidArgumentException
      */
-    public function __invoke(array $aRows, array $aAttributes = array(), $bEscape = true) {
+    public function __invoke(array $aRows, array $aAttributes = [], $bEscape = true)
+    {
 
         // Table class
         if (empty($aAttributes['class'])) {
@@ -40,31 +42,32 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The rows XHTML.
      * @throws \InvalidArgumentException
      */
-    public function renderTableRows(array $aRows, $bEscape = true) {
+    public function renderTableRows(array $aRows, $bEscape = true)
+    {
 
         $sMarkup = '';
-        if (!$aRows) {
+        if (! $aRows) {
             return $sMarkup;
         }
         if (isset($aRows['head'])) {
-            if (!is_array($aRows['head'])) {
+            if (! is_array($aRows['head'])) {
                 throw new \InvalidArgumentException('Argument "$aRows[\'head\']" expects an array, "' . (is_object($aRows['head']) ? get_class($aRows['head']) : gettype($aRows['head'])) . '" given');
             }
             $aHeadRows = $aRows['head'];
             unset($aRows['head']);
         }
         if (isset($aRows['body'])) {
-            if (!is_array($aRows['body'])) {
+            if (! is_array($aRows['body'])) {
                 throw new \InvalidArgumentException('Argument "$aRows[\'body\']" expects an array, "' . (is_object($aRows['body']) ? get_class($aRows['body']) : gettype($aRows['body'])) . '" given');
             }
             $aBodyRows = $aRows['body'];
             unset($aRows['body']);
         }
 
-        if (!isset($aBodyRows)) {
+        if (! isset($aBodyRows)) {
             $aBodyRows = $aRows;
         }
-        if (!isset($aHeadRows) && $aBodyRows) {
+        if (! isset($aHeadRows) && $aBodyRows) {
             // Define head from first row keys
             $aFirstRow = current($aBodyRows);
             if (\Zend\Stdlib\ArrayUtils::hasStringKeys($aFirstRow)) {
@@ -76,10 +79,10 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
             $sMarkup .= $this->renderHeadRows($aHeadRows);
         }
 
-        if (!empty($aBodyRows)) {
+        if (! empty($aBodyRows)) {
             $sMarkup .= '    <' . self::TABLE_BODY . '>' . PHP_EOL;
             foreach ($aBodyRows as $iKey => $aBodyRow) {
-                if (!is_array($aBodyRow)) {
+                if (! is_array($aBodyRow)) {
                     throw new \InvalidArgumentException('Body row "' . $iKey . '" expects an array, "' . (is_object($aBodyRow) ? get_class($aBodyRow) : gettype($aBodyRow)) . '" given');
                 }
                 $sMarkup .= $this->renderTableRow($aBodyRow, self::TABLE_DATA, $bEscape);
@@ -96,15 +99,16 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The "<thead>" rows XHTML.
      * @throws \InvalidArgumentException
      */
-    public function renderHeadRows(array $aHeadRows, $bEscape = true) {
+    public function renderHeadRows(array $aHeadRows, $bEscape = true)
+    {
         $sMarkup = '';
-        if (!$aHeadRows) {
+        if (! $aHeadRows) {
             return $sMarkup;
         }
 
         if (isset($aHeadRows['attributes'])) {
             $aHeadAttributes = $aHeadRows['attributes'];
-            if (!is_array($aHeadAttributes)) {
+            if (! is_array($aHeadAttributes)) {
                 throw new \InvalidArgumentException('Head "[\'attributes\']" expects an array, "' . (is_object($aHeadAttributes) ? get_class($aHeadAttributes) : gettype($aHeadAttributes)) . '" given');
             }
             $sHeadAttributes = $this->htmlAttribs($aHeadAttributes);
@@ -114,13 +118,13 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
         }
         if (isset($aHeadRows['rows'])) {
             $aHeadRows = $aHeadRows['rows'];
-            if (!is_array($aHeadRows)) {
+            if (! is_array($aHeadRows)) {
                 throw new \InvalidArgumentException('Head "[\'rows\']" expects an array, "' . (is_object($aHeadRows) ? get_class($aHeadRows) : gettype($aHeadRows)) . '" given');
             }
         }
 
-        if (!is_array(current($aHeadRows))) {
-            $aHeadRows = array($aHeadRows);
+        if (! is_array(current($aHeadRows))) {
+            $aHeadRows = [$aHeadRows];
         }
 
         $sMarkup .= '    <' . self::TABLE_HEAD . $sHeadAttributes . '>' . PHP_EOL;
@@ -137,12 +141,13 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
      * @param boolean $bEscape True espace html content of cells. Default True
      * @return string The row XHTML.
      */
-    public function renderTableRow(array $aRow, $sDefaultCellType, $bEscape = true) {
+    public function renderTableRow(array $aRow, $sDefaultCellType, $bEscape = true)
+    {
 
         $sRowAttributes = '';
         if (isset($aRow['attributes'])) {
             $aRowAttributes = $aRow['attributes'];
-            if (!is_array($aRowAttributes)) {
+            if (! is_array($aRowAttributes)) {
                 throw new \InvalidArgumentException('Argument "$aRow[\'attributes\']" expects an array, "' . (is_object($aRowAttributes) ? get_class($aRowAttributes) : gettype($aRowAttributes)) . '" given');
             }
             $sRowAttributes = $this->htmlAttribs($aRowAttributes);
@@ -153,7 +158,7 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
 
         if (isset($aRow['cells'])) {
             $aRow = $aRow['cells'];
-            if (!is_array($aRow)) {
+            if (! is_array($aRow)) {
                 throw new \InvalidArgumentException('Argument "$aRow[\'cells\']" expects an array, "' . (is_object($aRow) ? get_class($aRow) : gettype($aRow)) . '" given');
             }
         }
@@ -173,25 +178,26 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
      * @return string The cell XHTML.
      * @throws \InvalidArgumentException
      */
-    public function renderTableCell($sCell, $sDefaultCellType, $bEscape = true) {
+    public function renderTableCell($sCell, $sDefaultCellType, $bEscape = true)
+    {
 
         if (is_array($sCell)) {
-            if (!isset($sCell['data'])) {
+            if (! isset($sCell['data'])) {
                 throw new \InvalidArgumentException('Argument "$sCell[\'data\']" is undefined');
             }
             $sCellData = $sCell['data'];
-            if (!is_scalar($sCellData)) {
+            if (! is_scalar($sCellData)) {
                 throw new \InvalidArgumentException('Argument "$sCell[\'data\']" expects a scalar value, "' . (is_object($sCellData) ? get_class($sCellData) : gettype($sCellData)) . '" given');
             }
             if (isset($sCell['type'])) {
                 $sCellType = $sCell['type'];
-                if (!is_string($sCellType)) {
+                if (! is_string($sCellType)) {
                     throw new \InvalidArgumentException('Argument "$sCell[\'type\']" expects a string, "' . (is_object($sCellType) ? get_class($sCellType) : gettype($sCellType)) . '" given');
                 }
             }
             if (isset($sCell['attributes'])) {
                 $aAttributes = $sCell['attributes'];
-                if (!is_array($aAttributes)) {
+                if (! is_array($aAttributes)) {
                     throw new \InvalidArgumentException('Argument "$sCell[\'attributes\']" expects an array, "' . (is_object($aAttributes) ? get_class($aAttributes) : gettype($aAttributes)) . '" given');
                 }
                 $sAttributes = $this->htmlAttribs($aAttributes);
@@ -210,5 +216,4 @@ class Table extends \Zend\View\Helper\AbstractHtmlElement {
 
         return '            <' . $sCellType . $sAttributes . '>' . $sCellData . '</' . $sCellType . '>' . PHP_EOL;
     }
-
 }


### PR DESCRIPTION
`Radio` and `MultiCheckbox` elements have multiple options to select from. On the original code, if an `id` attribute was defined to one of these element types, it would simply be set on the input of the 1st option, which meant that clicking on the labels of the remaining options would not select them, as there was no association between the two `HTML` elements using the `for` attribute on the `label` element.

This patch fixes this behaviour, simply by assigning the original `id` attribute to the first option and then assigning a custom `id` attribute to the remaining options, instead of removing it.

PS:. Even though the fix was only implement in two files, I noticed that some parts of the code weren't following Zend's coding standards, so I ran the codesniffer fix script, resulting in many more files being changed.