### PR TITLE
Fix "Help text" and "Validation" on form elements

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -132,7 +132,7 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
             return sprintf(
                 static::$inputGroupFormat,
                 trim($sSpecialClass),
-                $sMarkup
+                $sMarkup . "%s"
             );
         }
 

--- a/src/TwbsHelper/Form/View/Helper/FormElementErrors.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElementErrors.php
@@ -10,7 +10,17 @@ use Zend\Form\View\Helper\FormElementErrors as ZendFormElementErrorsViewHelper;
  */
 class FormElementErrors extends ZendFormElementErrorsViewHelper
 {
+    /**@+
+     * @var string Templates for the open/close/separators for message tags
+     */
+    protected $messageCloseString     = '</div>';
+    protected $messageOpenFormat      = '<div%s>';
+    protected $messageSeparatorString = '<br />';
+
+    /**
+     * @var array Default attributes for the open format tag
+     */
     protected $attributes = [
-        'class' => 'form-text'
+        'class' => 'invalid-feedback'
     ];
 }

--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -33,13 +33,13 @@ class FormRow extends ZendFormRowViewHelper
     /**
      * @var string
      */
-    protected static $helpBlockFormat = '<p class="help-block">%s</p>';
+    protected static $helpBlockFormat = '<small class="form-text text-muted">%s</small>';
 
     /**
      * The class that is added to element that have errors
      * @var string
      */
-    protected $inputErrorClass = '';
+    protected $inputErrorClass = 'is-invalid';
 
     /**
      * @var string
@@ -332,8 +332,12 @@ class FormRow extends ZendFormRowViewHelper
 
                 // Render errors
                 if ($this->renderErrors) {
-                    $sElementContent .= $this->getElementErrorsHelper()->render($oElement);
+                    $sErrorMessages = $this->getElementErrorsHelper()->render($oElement);
+                } else {
+                    $sErrorMessages = '';
                 }
+
+                $sElementContent = sprintf($sElementContent, $sErrorMessages);
 
                 return $sElementContent;
 


### PR DESCRIPTION
Updated a few view helpers to match the new syntax for:

- [Help text](https://getbootstrap.com/docs/4.1/components/forms/#help-text);
- [Validation](https://getbootstrap.com/docs/4.1/components/forms/#validation).

Preview:

![zf3-bootstrap4-form-help-validation](https://user-images.githubusercontent.com/1101532/42477520-5139bbb4-83c9-11e8-9452-930a722631a7.png)