### PR TITLE
Fix FormRow view helper

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -337,7 +337,7 @@ class FormRow extends ZendFormRowViewHelper
                     $sErrorMessages = '';
                 }
 
-                $sElementContent = sprintf($sElementContent, $sErrorMessages);
+                $sElementContent .= $sErrorMessages;
 
                 return $sElementContent;
 


### PR DESCRIPTION
FormRow view helper rises an Exception when value of form input contain %-symbol.

And another problem is fixed by this commit - error messages were not rendered at all,
only red border around form element. Now it's rendered as it should be.