### PR TITLE
Complete fix of error messages rendering

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
@@ -103,7 +103,7 @@ class FormCheckbox extends ZendFormCheckboxViewHelper
             ) . $sElementContent;
         }
 
-        return $sElementContent . "%s";
+        return $sElementContent;
     }
 
 

--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -159,7 +159,7 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
                 static::$inputGroupFormat,
                 trim($sSpecialClass),
                 $sSpecialAttributes,
-                $sMarkup . "%s"
+                $sMarkup
             );
         }
 

--- a/src/TwbsHelper/Form/View/Helper/FormFile.php
+++ b/src/TwbsHelper/Form/View/Helper/FormFile.php
@@ -72,7 +72,7 @@ class FormFile extends FormInput
             '<input %s%s',
             $this->createAttributesString($aAttributes),
             $this->getInlineClosingBracket()
-        ) . "%s";
+        );
     }
 
     /**

--- a/src/TwbsHelper/Form/View/Helper/FormRadio.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRadio.php
@@ -49,7 +49,7 @@ class FormRadio extends ZendFormRadioViewHelper
             $sReturn = sprintf('%s', parent::render($oElement));
             $this->setSeparator($sSeparator);
 
-            return $sReturn . "%s";
+            return $sReturn;
         }
 
         if (isset($aElementOptions['btn-group']) && $aElementOptions['btn-group'] != false) {


### PR DESCRIPTION
Complete fix of error messages rendering. My previous fix was incomplete
and error messages doesn't show on input group addons. In addition the excess character % was displayed in checkbox, file, radio elements.