### PR TITLE
Fix typo in layout option

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/Form.php
+++ b/src/TwbsHelper/Form/View/Helper/Form.php
@@ -115,8 +115,8 @@ class Form extends ZendFormViewHelper
             }
 
             // Define layout option to form elements if not already defined
-            if ($sFormLayout && empty($aOptions['twb-layout'])) {
-                $oElement->setOption('twb-layout', $sFormLayout);
+            if ($sFormLayout && empty($aOptions['twbs-layout'])) {
+                $oElement->setOption('twbs-layout', $sFormLayout);
             }
 
             // Manage button group option

--- a/src/TwbsHelper/Form/View/Helper/Form.php
+++ b/src/TwbsHelper/Form/View/Helper/Form.php
@@ -32,7 +32,7 @@ class Form extends ZendFormViewHelper
      * @access public
      * @return TwbsHelperForm|string
      */
-    public function __invoke(FormInterface $oForm = null, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    public function __invoke(FormInterface $oForm = null, $sFormLayout = null)
     {
         $this->sFormLayout = $sFormLayout;
 
@@ -54,7 +54,7 @@ class Form extends ZendFormViewHelper
      * @access public
      * @return string
      */
-    public function render(FormInterface $oForm, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    public function render(FormInterface $oForm, $sFormLayout = null)
     {
         // Prepare form if needed
         if (method_exists($oForm, 'prepare')) {
@@ -80,7 +80,7 @@ class Form extends ZendFormViewHelper
      * @access protected
      * @return string
      */
-    protected function renderElements(FormInterface $oForm, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    protected function renderElements(FormInterface $oForm, $sFormLayout = null)
     {
         // Store button groups
         $aButtonGroups = [];
@@ -174,7 +174,7 @@ class Form extends ZendFormViewHelper
      * @access protected
      * @return TwbsHelper\Form\View\Helper\TwbsHelperForm
      */
-    protected function setFormClass(FormInterface $oForm, string $sFormLayout = self::LAYOUT_HORIZONTAL)
+    protected function setFormClass(FormInterface $oForm, $sFormLayout = null)
     {
         if (is_string($sFormLayout)) {
             $sLayoutClass = 'form-' . $sFormLayout;


### PR DESCRIPTION
Form view helper has typo in layout option name: 'twb-layout' instead of 'twbs-layout' which used in other files.