### PR TITLE
Fix render of checkbox/radio in append/prepend

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -4,6 +4,8 @@ namespace TwbsHelper\Form\View\Helper;
 use Traversable;
 use InvalidArgumentException;
 use LogicException;
+use Zend\Form\Element\Checkbox;
+use Zend\Form\Element\Radio;
 use Zend\Form\ElementInterface;
 use Zend\Form\View\Helper\FormElement as ZendFormElementViewHelper;
 use Zend\Form\Element\Collection;
@@ -230,7 +232,12 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
                 ['disable-twbs' => true]
             ));
 
-            $sMarkup .= $this->render($aAddOnOptions['element']);
+            if ($aAddOnOptions['element'] instanceof Checkbox || $aAddOnOptions['element'] instanceof Radio) {
+                $sMarkup .= sprintf(static::$addonTextFormat, $this->render($aAddOnOptions['element']));
+            }
+            else {
+                $sMarkup .= $this->render($aAddOnOptions['element']);
+            }
         }
         
         $sAttributes = '';


### PR DESCRIPTION
Fix incorrect render of checkbox/radio elements in append/prepend
blocks. Added input-group-text wrapper to this elements according to
Bootstrap 4 docs.