### PR TITLE
Added ability to use of custom attributes

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -13,6 +13,8 @@ return [
             'submit',
             'static',
         ],
+        'validTagAttributes' => [],
+        'validTagAttributePrefixes' => [],
         'type_map'  => [],
         'class_map' => [],
     ],
@@ -30,7 +32,7 @@ return [
             'alert'        => 'TwbsHelper\View\Helper\Alert',
             'badge'        => 'TwbsHelper\View\Helper\Badge',
             'blockquote'   => 'TwbsHelper\View\Helper\Blockquote',
-			'buttonGroup'  => 'TwbsHelper\View\Helper\ButtonGroup',
+            'buttonGroup'  => 'TwbsHelper\View\Helper\ButtonGroup',
             'figure'       => 'TwbsHelper\View\Helper\Figure',
             'htmlList'     => 'TwbsHelper\View\Helper\HtmlList',
             'table'        => 'TwbsHelper\View\Helper\Table',
@@ -47,12 +49,6 @@ return [
             'formRow'           => 'TwbsHelper\Form\View\Helper\FormRow',
             'formStatic'        => 'TwbsHelper\Form\View\Helper\FormStatic',
             'formErrors'        => 'TwbsHelper\Form\View\Helper\FormErrors',
-
-            // Glyphicon
-            'glyphicon' => 'TwbsHelper\View\Helper\Glyphicon',
-
-            // FontAwesome
-            'fontAwesome' => 'TwbsHelper\View\Helper\FontAwesome',
 
             // ZF3
             'form_button'         => 'TwbsHelper\Form\View\Helper\FormButton',

--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -168,6 +168,31 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
         return $sMarkup;
     }
 
+    /**
+     * Render element by helper name
+     *
+     * @param string $name
+     * @param ElementInterface $element
+     * @return string
+     */
+    protected function renderHelper($name, ElementInterface $element)
+    {
+        $helper = $this->getView()->plugin($name);
+
+        if (count($this->options->getValidTagAttributes())) {
+            foreach ($this->options->getValidTagAttributes() as $attribute) {
+                $helper->addValidAttribute($attribute);
+            }
+        }
+
+        if (count($this->options->getValidTagAttributePrefixes())) {
+            foreach ($this->options->getValidTagAttributePrefixes() as $prefix) {
+                $helper->addValidAttributePrefix($prefix);
+            }
+        }
+
+        return $helper($element);
+    }
 
     /**
      * renderAddOn

--- a/src/TwbsHelper/Form/View/Helper/FormElement.php
+++ b/src/TwbsHelper/Form/View/Helper/FormElement.php
@@ -179,13 +179,13 @@ class FormElement extends ZendFormElementViewHelper implements TranslatorAwareIn
     {
         $helper = $this->getView()->plugin($name);
 
-        if (count($this->options->getValidTagAttributes())) {
+        if ($this->options->getValidTagAttributes()) {
             foreach ($this->options->getValidTagAttributes() as $attribute) {
                 $helper->addValidAttribute($attribute);
             }
         }
 
-        if (count($this->options->getValidTagAttributePrefixes())) {
+        if ($this->options->getValidTagAttributePrefixes()) {
             foreach ($this->options->getValidTagAttributePrefixes() as $prefix) {
                 $helper->addValidAttributePrefix($prefix);
             }

--- a/src/TwbsHelper/Options/ModuleOptions.php
+++ b/src/TwbsHelper/Options/ModuleOptions.php
@@ -15,6 +15,12 @@ class ModuleOptions extends AbstractOptions
     protected $ignoredViewHelpers;
 
     // @var array
+    protected $validTagAttributes;
+
+    // @var array
+    protected $validTagAttributePrefixes;
+
+    // @var array
     protected $classMap;
 
     // @var array
@@ -42,6 +48,60 @@ class ModuleOptions extends AbstractOptions
     public function setIgnoredViewHelpers(array $aIgnoredViewHelpers)
     {
         $this->ignoredViewHelpers = $aIgnoredViewHelpers;
+
+        return $this;
+    }
+
+
+    /**
+     * getValidTagAttributes
+     *
+     * @access public
+     * @return array
+     */
+    public function getValidTagAttributes()
+    {
+        return $this->validTagAttributes;
+    }
+
+
+    /**
+     * setIgnoredViewHelpers
+     *
+     * @param array $aValidTagAttributes
+     * @access public
+     * @return \TwbsHelper\Options\ModuleOptions
+     */
+    public function setValidTagAttributes(array $aValidTagAttributes)
+    {
+        $this->validTagAttributes = $aValidTagAttributes;
+
+        return $this;
+    }
+
+
+    /**
+     * getValidTagAttributePrefixes
+     *
+     * @access public
+     * @return array
+     */
+    public function getValidTagAttributePrefixes()
+    {
+        return $this->validTagAttributePrefixes;
+    }
+
+
+    /**
+     * setValidTagAttributePrefixes
+     *
+     * @param array $aValidTagAttributePrefixes
+     * @access public
+     * @return \TwbsHelper\Options\ModuleOptions
+     */
+    public function setValidTagAttributePrefixes(array $aValidTagAttributePrefixes)
+    {
+        $this->validTagAttributePrefixes = $aValidTagAttributePrefixes;
 
         return $this;
     }


### PR DESCRIPTION
Added ability to use of custom attributes on form elements (for example
'v-model' attribute for Vue). Attributes can be assigned via config
file. Also added ability to use of groups of custom attributes by
defining it via allowed prefixes array.