### PR TITLE
"twbs-row-class" option was ignored

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -28,7 +28,7 @@ class FormRow extends ZendFormRowViewHelper
     /**
      * @var string
      */
-    protected static $checkboxFormat = '<div class="form-check">%s</div>';
+    protected static $checkboxFormat = '<div class="form-check %s">%s</div>';
 
     /**
      * @var string
@@ -318,7 +318,7 @@ class FormRow extends ZendFormRowViewHelper
 
                 // Checkbox elements are a special case, element is already rendered into label
                 if ($sElementType === 'checkbox') {
-                    $sElementContent = sprintf(static::$checkboxFormat, $sElementContent);
+                    $sElementContent = sprintf(static::$checkboxFormat, $oElement->getOption('twbs-row-class'), $sElementContent);
                 } else {
                     if ($sLabelPosition === self::LABEL_PREPEND) {
                         $sElementContent = $sLabelOpen . $sLabelContent . $sLabelClose . $sElementContent;


### PR DESCRIPTION
Any reason the «twbs-row-class» option was ignored for the checkbox element ?